### PR TITLE
Add tmux to common system packages

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -30,4 +30,5 @@ mod 'ssl',      :git => 'git://github.com/alphagov/puppet-ssl.git',
                 :ref => '23bbb5ab57f26269acce3d4b43e643781747a551'
 mod 'upstart',  :git => 'git://github.com/bison/puppet-upstart.git',
                 :ref => '05a10a3a58de3543eb51bb782a249cebf71f5cd8'
-
+mod 'tmux',     :git => 'git://github.com/endore-me/puppet-tmux.git',
+                :ref => '32db4ac6ad65a934c5eddd9afcf0c4f61f7c0924'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -86,6 +86,13 @@ GIT
       puppetlabs/stdlib (>= 0.1.6)
 
 GIT
+  remote: git://github.com/endore-me/puppet-tmux.git
+  ref: 32db4ac6ad65a934c5eddd9afcf0c4f61f7c0924
+  sha: 32db4ac6ad65a934c5eddd9afcf0c4f61f7c0924
+  specs:
+    tmux (0.0.1)
+
+GIT
   remote: git://github.com/stankevich/puppet-python.git
   ref: f508b71d534f3c67db12886fa914cb4ef74bbe7a
   sha: f508b71d534f3c67db12886fa914cb4ef74bbe7a
@@ -111,6 +118,7 @@ DEPENDENCIES
   saz/ntp (= 2.0.3)
   saz/rsyslog (= 2.0.0)
   ssl (>= 0)
+  tmux (>= 0)
   torrancew/account (= 0.0.3)
   upstart (>= 0)
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -84,4 +84,5 @@ system_packages:
     - curl
     - htop
     - ssl-cert
+    - tmux
     - vim

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -84,5 +84,4 @@ system_packages:
     - curl
     - htop
     - ssl-cert
-    - tmux
     - vim

--- a/modules/performanceplatform/manifests/base.pp
+++ b/modules/performanceplatform/manifests/base.pp
@@ -9,6 +9,7 @@ class performanceplatform::base {
     include python
     include rsyslog::client
     include ssh::server
+    include tmux
     include ufw
     class {'gstatsd': require => Class['python::install'] }
 


### PR DESCRIPTION
When I do have to login to a machine, it's nice to have a terminal-
multiplexing capability and let me handle flakey VPN connections in
a graceful manner, so that any child processes aren't accidentally
killed.

Not sure if we should do it like this, or like we did for GOV.UK.

Thoughts?
