### PR TITLE
Add admin.backdrop app

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -4,6 +4,12 @@ classes:
     - 'backdrop'
 
 backdrop_apps:
+    admin.backdrop:
+        port:       3037
+        # This is a placeholder until we extract a separate app
+        app_module: 'backdrop.write.api:app'
+        user:       'deploy'
+        group:      'deploy'
     read.backdrop:
         port:       3038
         app_module: 'backdrop.read.api:app'


### PR DESCRIPTION
We need to have a suitable vhost in nginx. This adds that, plus gets us
closer to breaking out a separate admin application. Slightly nasty in
that we're going to be running 2 instances of write.backdrop until that
happens but hopefully the transition will be smoother when we do make
the leap.

FAO @maxfliri / @alexmuller / @robyoung 
