### PR TITLE
Redirect admin root

### DIFF
--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -82,8 +82,14 @@ sub vcl_recv {
   # Routing
   # Allow all HTTP Methods for admin
   if (req.http.Host ~ "^admin\..*") {
-    set req.http.Host = "admin.backdrop";
-    set req.backend   = admin_director;
+    if (req.url ~ "^\/?$") {
+      # redirect / to /_user for the admin application
+      set req.http.x-Redir-Url = regsub(req.url, "^(.+)$", "/_user");
+      error 667 req.http.x-Redir-Url;
+    } else {
+      set req.http.Host = "admin.backdrop";
+      set req.backend   = admin_director;
+    }
   # Send POST requests to the write api
   } else if (req.request == "POST") {
     if (req.http.Authorization ~ "^Bearer .*") {


### PR DESCRIPTION
https://admin.performance.service.gov.uk ->
https://admin.performance.service.gov.uk/_user

This is needed due to the host names in nginx for the backend servers
not having the FQDN, but just the local name.

Ideally this will be removed once we have a separate admin app. Until
then...

/cc @samjsharpe 
