### PR TITLE
Add Google credentials to jumpbox (for jenkins)

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -32,3 +32,5 @@ mod 'upstart',  :git => 'git://github.com/bison/puppet-upstart.git',
                 :ref => '05a10a3a58de3543eb51bb782a249cebf71f5cd8'
 mod 'tmux',     :git => 'git://github.com/endore-me/puppet-tmux.git',
                 :ref => '32db4ac6ad65a934c5eddd9afcf0c4f61f7c0924'
+mod 'google_credentials', :git => 'git://github.com/alphagov/puppet-google_credentials.git',
+                          :ref => 'a64f9e5c051a0d38e59441457b52a7afeeebed24'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -33,6 +33,13 @@ GIT
       puppetlabs/stdlib (>= 2.0.0)
 
 GIT
+  remote: git://github.com/alphagov/puppet-google_credentials.git
+  ref: a64f9e5c051a0d38e59441457b52a7afeeebed24
+  sha: a64f9e5c051a0d38e59441457b52a7afeeebed24
+  specs:
+    google_credentials (0.0.1)
+
+GIT
   remote: git://github.com/alphagov/puppet-gstatsd.git
   ref: c7eb9b99c34194d92e9e8494bdeed1b29b43ed60
   sha: c7eb9b99c34194d92e9e8494bdeed1b29b43ed60
@@ -105,6 +112,7 @@ DEPENDENCIES
   backdrop (>= 0)
   collectd (>= 0)
   dwerder/graphite (= 2.4.1)
+  google_credentials (>= 0)
   gstatsd (>= 0)
   harden (>= 0)
   jenkins (>= 0)

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -79,6 +79,14 @@ python::dev:        true
 python::virtualenv: true
 python::pip:        true
 
+google_credentials::client_id: "google client id"
+google_credentials::client_secret: "google client secret"
+google_credentials::refresh_tokens:
+    analytics:
+        refresh_token: "analytics refresh token"
+    drive:
+        refresh_token: "drive refresh token"
+
 system_packages:
     - at
     - curl

--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -5,6 +5,7 @@ classes:
     - 'python'
     - 'nginx::server'
     - 'rsyslog::server'
+    - 'google_credentials'
 
 graphite::gr_apache_port:       9080
 graphite::gr_apache_port_https: 9443


### PR DESCRIPTION
Add a module to put Google credentials in a know place.

See: [puppet-google_credentials](https://github.com/alphagov/puppet-google_credentials)

@samjsharpe @jabley 
