### PR TITLE
Create trans. explorer directory structure

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -2,6 +2,7 @@
 classes:
     - 'nginx::server'
     - 'varnish'
+    - 'transactions-explorer'
 
 ufw_rules:
     allow-http-from-anywhere:
@@ -21,7 +22,7 @@ vhost_proxies:
         ssl:           true
         ssl_redirect:  true
         upstream_port: 7999
-vhost_static:
-    transactions-explorer:
-        servername:   "%{::transactions_explorer_vhost}"
-        vhostroot:    "/opt/transactions-explorer/current"
+
+transactions-explorer::servername: "%{::transactions_explorer_vhost}"
+transactions-explorer::user:       "deploy"
+transactions-explorer::group:      "deploy"

--- a/manifests/nodes.pp
+++ b/manifests/nodes.pp
@@ -39,11 +39,6 @@ node default {
         create_resources( 'nginx::vhost::proxy', $vhost_proxies )
     }
 
-    $vhost_static = hiera_hash( 'vhost_static', {} )
-    if !empty($vhost_static) {
-        create_resources( 'nginx::vhost', $vhost_static )
-    }
-
     # Install the apps
     $backdrop_apps = hiera_hash( 'backdrop_apps', {} )
     if !empty($backdrop_apps) {

--- a/modules/transactions-explorer/manifests/init.pp
+++ b/modules/transactions-explorer/manifests/init.pp
@@ -1,0 +1,16 @@
+class transactions-explorer(
+  $servername,
+  $user,
+  $group,
+) {
+  $app_path = "/opt/${title}"
+  file { ["${app_path}", "${app_path}/releases", "${app_path}/artefacts"]:
+    ensure => directory,
+    owner  => $user,
+    group  => $group,
+  }
+  nginx::vhost { "$title":
+    servername => $servername,
+    vhostroot  => "${app_path}/current",
+  }
+}


### PR DESCRIPTION
Done in puppet rather than deployment because it's easier to manage
ownership. This also moves transactions explorer setup into it's own
module / class as there's more than one thing happening in relation to
it now.
