### PR TITLE
Protect the SU binary

### DIFF
--- a/modules/performanceplatform/manifests/base.pp
+++ b/modules/performanceplatform/manifests/base.pp
@@ -46,4 +46,10 @@ FACTER_machine_environment=${environment}
         content => '%gds ALL=(ALL) NOPASSWD: ALL
 '
     }
+    file { '/bin/su':
+        ensure => present,
+        mode   => '4750',
+        owner  => 'root',
+        group  => 'gds',
+    }
 }


### PR DESCRIPTION
The ITHC has identified that anyone can run SU. This commit
restricts that to only the root user and the members of the
gds group.
