### PR TITLE
[#55989114] Fix requirement to provision twice.

### DIFF
--- a/manifests/nodes.pp
+++ b/manifests/nodes.pp
@@ -1,5 +1,8 @@
 # Everything in this node definition depends on Hiera
 
+# This defines the role of the node
+$machine_role     = regsubst($::hostname, '^(.*)-\d$', '\1')
+
 # Nginx Vhosts for later use
 $domain_name        = hiera('domain_name')
 $public_domain_name = hiera('public_domain_name', $domain_name)
@@ -14,8 +17,6 @@ $www_vhost          = join(['www',$public_domain_name],'.')
 hiera_include('classes')
 
 node default {
-    # This defines the role of the node
-    $machine_role     = regsubst($::hostname, '^(.*)-\d$', '\1')
 
     # Environment specific variables
     $environment      = hiera('environment')


### PR DESCRIPTION
Because there is a call to heira before the machine_role var is setup,
it will not include the correct role-[machine_role].yaml. This means the
box does not get correctly setup and requires a second run of puppet
before it is correctly setup.
