### PR TITLE
Add monitoring to all nginx instances

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -31,3 +31,8 @@ nginx::server::server_names_hash_bucket_size: 128
 nginx_conf:
     logging:
         template: performanceplatform/nginx.logging.conf.erb
+
+lumberjack_instances:
+    nginx:
+        log_files: [ '/var/log/nginx/*.access.json.log' ]
+        fields: { "tag": "nginx" }

--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -52,9 +52,22 @@ vhost_proxies:
         ssl_redirect:    true
         upstream_server: 'localhost'
         upstream_port:   8080
+        access_logs:
+            '{name}.access.json.log': 'json_event'
     graphite-vhost:
         servername:      "%{::graphite_vhost}"
         ssl:             true
         ssl_redirect:    true
         upstream_server: 'graphite'
         upstream_port:   80
+        access_logs:
+            '{name}.access.json.log': 'json_event'
+
+nginx_conf:
+    logging:
+        template: performanceplatform/nginx.logging.conf.erb
+
+lumberjack_instances:
+    nginx:
+        log_files: [ '/var/log/nginx/*.access.json.log' ]
+        fields: { "tag": "nginx" }

--- a/hieradata/role-monitoring.yaml
+++ b/hieradata/role-monitoring.yaml
@@ -18,6 +18,9 @@ ufw_rules:
     allowcarbonfromanywhere:
         port: 2003
         ip:   'any'
+    allowlumberjackfromanywhere:
+        port: 3456
+        ip:   'any'
     allowhttpfromall:
         port: 80
         ip:   'any'
@@ -46,5 +49,5 @@ nginx_conf:
 
 lumberjack_instances:
     nginx:
-        log_files: [ '/var/log/nginx/*.log' ]
+        log_files: [ '/var/log/nginx/*.access.json.log' ]
         fields: { "tag": "nginx" }


### PR DESCRIPTION
Lumberjack was only monitoring the nginx logs on monitoring-1. I have
now added lumberjack instances to the rest of the boxes and opened the
port in ufw for logstash.

I have also had the monitoring boxes only tail access logs.
