### PR TITLE
Move ruby-dev dep into puppet

### DIFF
--- a/modules/performanceplatform/manifests/base.pp
+++ b/modules/performanceplatform/manifests/base.pp
@@ -62,9 +62,14 @@ FACTER_machine_environment=${environment}
         group  => 'gds',
     }
 
+    package { 'ruby1.9.1-dev':
+      ensure => present,
+    }
+
     package {'sensu-plugin':
       ensure   => installed,
-      provider => gem
+      provider => gem,
+      require  => Package['ruby1.9.1-dev'],
     }
 
     vcsrepo { '/etc/sensu/community-plugins':

--- a/tools/bootstrap
+++ b/tools/bootstrap
@@ -28,8 +28,6 @@ check_ruby() {
   echo "--> Check for Ruby" | pp
   [[ $(dpkg -s ruby1.9.1 >/dev/null 2>&1) ]] || \
     apt-get install -qq ruby1.9.1 2>&1 | pp
-  [[ $(dpkg -s ruby1.9.1-dev >/dev/null 2>&1) ]] || \
-    apt-get install -qq ruby1.9.1-dev 2>&1 | pp
 }
 
 check_bundler() {

--- a/tools/bootstrap-vagrant
+++ b/tools/bootstrap-vagrant
@@ -36,8 +36,6 @@ check_ruby() {
   echo "--> Check for Ruby" | pp
   [[ $(dpkg -s ruby1.9.1 >/dev/null 2>&1) ]] || \
     apt-get install -qq ruby1.9.1 2>&1 | pp
-  [[ $(dpkg -s ruby1.9.1-dev >/dev/null 2>&1) ]] || \
-    apt-get install -qq ruby1.9.1-dev 2>&1 | pp
 }
 
 check_bundler() {


### PR DESCRIPTION
The bootstrap scripts are not run on the servers when deployment occurs
and ruby-dev is required by the sensu-plugin gem. To get around thi we
should move the dep into puppet.
