### PR TITLE
Update Node.js from 0.10.20 to 0.10.21

### DIFF
--- a/modules/performanceplatform/manifests/nodejs.pp
+++ b/modules/performanceplatform/manifests/nodejs.pp
@@ -1,11 +1,11 @@
 class performanceplatform::nodejs {
-    package { 'nodejs':
-        ensure  => "0.10.20-1chl1~${::lsbdistcodename}1",
-        require => Apt::Ppa['ppa:gds/performance-platform']
-    }
-    package { 'grunt-cli':
-        ensure   => '0.1.9',
-        provider => 'npm',
-        require  => Package['nodejs'],
-    }
+  package { 'nodejs':
+    ensure  => "0.10.21-1chl1~${::lsbdistcodename}1",
+    require => [Apt::Ppa['ppa:gds/performance-platform'], Exec['apt-get-update']],
+  }
+  package { 'grunt-cli':
+    ensure   => '0.1.9',
+    provider => 'npm',
+    require  => Package['nodejs'],
+  }
 }


### PR DESCRIPTION
Make sure that apt-get update has run since the last time,
or we won't have that version cached.
