### PR TITLE
Disable travis email notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ before_install:
   - gem install puppet
   - gem install librarian-puppet
   - librarian-puppet install
-
+notifications:
+  email: false


### PR DESCRIPTION
We tend to use one of:
- github travis status bar
- jenkins job status
- build dashboard
