### PR TITLE
appease the multiple ssh-keys feature

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -3,13 +3,17 @@ accounts:
         alexmuller:
             home_dir: /home/alexmuller
             comment: Alex Muller
-            ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAABAQDxuVkxqVy8kRncaG0cm/B8p7YTk7UjwE6xgUkfzIV97xAaRfNyZUI9Ur/w2x945r5IiuKGp61UHMzsGBEgmsDDNvukguY/a02yXZRySxf3ThlsqG/w7DX9uNwVEeLAA95es4P+6iApbRnBTQX7Nx/XsIa3hy8Uwr3T+pcrXCRIczhfuaiugQ/jh9IlkIC1I6UHbYoli8o5upTh9SbnimU/VXiUIO4v5z1CyLgQHfeE6VBxYO6HCQqRJg7uB4vNS5wAWyTYx4XinkS3ScjKmQr+wExyRy0vgnj5f+oVFNLgARh9lh2ViJ6ntGw8ww10b3xY/Bc/qoeFZKJjb89aMhLb
+            ssh_keys:
+                alexmuller:
+                    key: AAAAB3NzaC1yc2EAAAADAQABAAABAQDxuVkxqVy8kRncaG0cm/B8p7YTk7UjwE6xgUkfzIV97xAaRfNyZUI9Ur/w2x945r5IiuKGp61UHMzsGBEgmsDDNvukguY/a02yXZRySxf3ThlsqG/w7DX9uNwVEeLAA95es4P+6iApbRnBTQX7Nx/XsIa3hy8Uwr3T+pcrXCRIczhfuaiugQ/jh9IlkIC1I6UHbYoli8o5upTh9SbnimU/VXiUIO4v5z1CyLgQHfeE6VBxYO6HCQqRJg7uB4vNS5wAWyTYx4XinkS3ScjKmQr+wExyRy0vgnj5f+oVFNLgARh9lh2ViJ6ntGw8ww10b3xY/Bc/qoeFZKJjb89aMhLb
             groups:
                 - gds
         bt:
             home_dir: /home/bt
             comment: Brett Thomas - ITHC
-            ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAABAQC8WVtkr26X+eAwIEAWZPv+DtXEt6rSVg0mgrdvxfNotAWz85UrD7ds2L+hwgcCH2Eqpk5EqTueOlk3Slz6ec4DiMvjdXgs65pFHw3+utxobmArn5NTJnm0VnM57vwsZteRsjkj8OT38COcHR8PgXvVJqU0hctkcIRbRQOxUs68pckOgNm1lTfolYXOdFZLiIFXyyg83n/YXN59Ux1fERTEmwrADE+fQBgKs+f5KDc0OmwjFEwiYXFBi0d7zy5fVTw/IqHGXo6pH5BB3/4aOH5Yrbtn9xB/lEvwvG6TVjNIjRmy/HL7b8/feWs9ckt4rv31m2StndoBx/kWCGXjlmwD
+            ssh_keys:
+                bt:
+                    key: AAAAB3NzaC1yc2EAAAADAQABAAABAQC8WVtkr26X+eAwIEAWZPv+DtXEt6rSVg0mgrdvxfNotAWz85UrD7ds2L+hwgcCH2Eqpk5EqTueOlk3Slz6ec4DiMvjdXgs65pFHw3+utxobmArn5NTJnm0VnM57vwsZteRsjkj8OT38COcHR8PgXvVJqU0hctkcIRbRQOxUs68pckOgNm1lTfolYXOdFZLiIFXyyg83n/YXN59Ux1fERTEmwrADE+fQBgKs+f5KDc0OmwjFEwiYXFBi0d7zy5fVTw/IqHGXo6pH5BB3/4aOH5Yrbtn9xB/lEvwvG6TVjNIjRmy/HL7b8/feWs9ckt4rv31m2StndoBx/kWCGXjlmwD
             groups:
                 - gds
         bthomas:
@@ -21,37 +25,49 @@ accounts:
         jabley:
             home_dir: /home/jabley
             comment: James Abley
-            ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAABAQC2568vUQp+Fb7bmSML5OHn0N8gmOjQp9LSE/HPh+xybMiX6ql8JhxDhPGl2NZl2zVmhICLlhY9HcX4E1w2mHY2MgSsoE148QPomYmcjkIkcQxh6nFN4Ga++foTu6WPkUQJudah3ML/XNs/D+yMgxk8nkel6EvIqgbbswlTQp22FmqGfk9XzJqX0mfTrlggJlacYlw+Z4JT4NhoFX4EefSSX0c6qm7fipX2U7M3hJUXxsakj0jM5GOk9xrEVCRUgx5M8l3rS2DwF0W54RewAdq5J9KdnIQi5DOsbVJKnR1flpoaIVuRq1x/feZ4yqi53ctYX5MT8tb6CLc8zmuU7XyR
+            ssh_keys:
+                jabley:
+                    key: AAAAB3NzaC1yc2EAAAADAQABAAABAQC2568vUQp+Fb7bmSML5OHn0N8gmOjQp9LSE/HPh+xybMiX6ql8JhxDhPGl2NZl2zVmhICLlhY9HcX4E1w2mHY2MgSsoE148QPomYmcjkIkcQxh6nFN4Ga++foTu6WPkUQJudah3ML/XNs/D+yMgxk8nkel6EvIqgbbswlTQp22FmqGfk9XzJqX0mfTrlggJlacYlw+Z4JT4NhoFX4EefSSX0c6qm7fipX2U7M3hJUXxsakj0jM5GOk9xrEVCRUgx5M8l3rS2DwF0W54RewAdq5J9KdnIQi5DOsbVJKnR1flpoaIVuRq1x/feZ4yqi53ctYX5MT8tb6CLc8zmuU7XyR
             groups:
                 - gds
         pauloschneider:
             home_dir: /home/pauloschneider
             comment: Paulo Schneider
-            ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAABAQCvvZH/S3hteksF52XP6RWyQJUYb/QdI6QyBHbx6lNnHTT0yvmHiS8DcnmI2IDbJqVxXJcaTReOwR2oqhjJ1IJSJZifutXcJsTb5Mc+7XaUWJY7gYCLkZe5PHooxif3AC5RZxhoQEIr+fMBubHhepDQQzie3g6zchr4ENxrKEwUt3VlOA/NZVE0zqmvZ4O6x7+mLJ9BeQuU558JVlJ6XkPqKOiLkLkUr58UOqgaYqU7t29T8IlFRILWoVqJ7WG6wbE6vVsTxktC0PhGUvN4IlilfFIIWh18duGo5dwQJ6E7m9uRAvIYjH+4Y5WnrGBiYt6ljQI/f+kI+iDgG45ewz9P
+            ssh_keys:
+                pauloschneider:
+                    key: AAAAB3NzaC1yc2EAAAADAQABAAABAQCvvZH/S3hteksF52XP6RWyQJUYb/QdI6QyBHbx6lNnHTT0yvmHiS8DcnmI2IDbJqVxXJcaTReOwR2oqhjJ1IJSJZifutXcJsTb5Mc+7XaUWJY7gYCLkZe5PHooxif3AC5RZxhoQEIr+fMBubHhepDQQzie3g6zchr4ENxrKEwUt3VlOA/NZVE0zqmvZ4O6x7+mLJ9BeQuU558JVlJ6XkPqKOiLkLkUr58UOqgaYqU7t29T8IlFRILWoVqJ7WG6wbE6vVsTxktC0PhGUvN4IlilfFIIWh18duGo5dwQJ6E7m9uRAvIYjH+4Y5WnrGBiYt6ljQI/f+kI+iDgG45ewz9P
             groups:
                 - gds
         robyoung:
             home_dir: /home/robyoung
             comment: Rob Young
-            ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Ow1NSyFzV31HAuIf7FFrGIki01sM4+PUdnHrBtTqNFrraGTqcrRKOs8oHtDMhiGC9MPQWvgTMo/sDdAYp3W5SelBJX3L2J0ixKU9D7FNn963SGxWgfuZGTYvu50uDbPwGXH/FXaa99lo3FDv4o2hodC3TRPISAIS3fGXD/K1RuczvIeWfrYAUg2yC01Jv6XzJvHeVVfgQkp0YkV2J0Y5+hXJlcyxmFMdOZeXF5o68ypac/KEu5ksmFX+9h8YPjJ9vidVqzDQosSTA/2W8zTiqTztHeAFOgp/uw8XgLxzel8FLTE6xyu0WSAQHVTZfm5r6U/blft/Q3gcDldrLzRD
+            ssh_keys:
+                robyoung:
+                    key: AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Ow1NSyFzV31HAuIf7FFrGIki01sM4+PUdnHrBtTqNFrraGTqcrRKOs8oHtDMhiGC9MPQWvgTMo/sDdAYp3W5SelBJX3L2J0ixKU9D7FNn963SGxWgfuZGTYvu50uDbPwGXH/FXaa99lo3FDv4o2hodC3TRPISAIS3fGXD/K1RuczvIeWfrYAUg2yC01Jv6XzJvHeVVfgQkp0YkV2J0Y5+hXJlcyxmFMdOZeXF5o68ypac/KEu5ksmFX+9h8YPjJ9vidVqzDQosSTA/2W8zTiqTztHeAFOgp/uw8XgLxzel8FLTE6xyu0WSAQHVTZfm5r6U/blft/Q3gcDldrLzRD
             groups:
                 - gds
         roc:
             home_dir: /home/roc
             comment: Ralph Cowling
-            ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAABAQDZEAxcu70/IbytBYrTh6jDsouuH8mjBlRPoq8e3eEWryQWe6+wevh/c29hiG1J1iRVYfUzxnVV2lIlxh3YOPG4TIwMFHS1rMpmR8j0VTbNw89Jf2O90X+wZa5ERlBRpXWhV98EMLWPMXmSTo7bXAdIZvNolAkw0GaIV9ozbZHV69hcXLxXFgO7KSp6J5ByYcqPwHASmZhfSLEYNSmD8JnwU0Z9lJl+YrlT9x0OrY79lCfSMIfCJ+l8+nMsNi7YrPEP6RrtCR3mStKmBVtiLukclxKTkx4nDxxuYThlZwVz90VBiRQHerK62EKmxky9Wrmx3KPT5dQDOCQ8gTmfTPOl
+            ssh_keys:
+                roc:
+                    key: AAAAB3NzaC1yc2EAAAADAQABAAABAQDZEAxcu70/IbytBYrTh6jDsouuH8mjBlRPoq8e3eEWryQWe6+wevh/c29hiG1J1iRVYfUzxnVV2lIlxh3YOPG4TIwMFHS1rMpmR8j0VTbNw89Jf2O90X+wZa5ERlBRpXWhV98EMLWPMXmSTo7bXAdIZvNolAkw0GaIV9ozbZHV69hcXLxXFgO7KSp6J5ByYcqPwHASmZhfSLEYNSmD8JnwU0Z9lJl+YrlT9x0OrY79lCfSMIfCJ+l8+nMsNi7YrPEP6RrtCR3mStKmBVtiLukclxKTkx4nDxxuYThlZwVz90VBiRQHerK62EKmxky9Wrmx3KPT5dQDOCQ8gTmfTPOl
             groups:
                 - gds
         ssharpe:
             home_dir: /home/ssharpe
             comment: Sam J Sharpe
-            ssh_key: AAAAB3NzaC1yc2EAAAABIwAAAQEAyNoMftFLf3w0NOW7J0KUwOx9897CU352n3zKD3p/GCcdH4eMv1QI0BhjItZplWG8TzFSBfWOOSruRh1Gksa1l1jiQcisEio6Wr7kZ7bpvMMA45ZoaDc26HTB+r0BZkNn7Lwwxxvy+1pbqStnnKzb9OTYIyVkb495LS0x1EL/P9S/NWtpm8ZULa1JDplYMA5SqMZnhmlGAXdh8UnjdcdOgOm2ngA+geJBSzVbABECiIAklHU1PRzOtrq8SuO8JmXW6NkuL0aabdTgE6noIm+Nn7T5ufZpOpIGYimVI8+mu+efcBzAp5Q0vTRgSBLfggdczZbFfPXpIt1Ib+LEf+Cuqw==
+            ssh_keys:
+                ssharpe:
+                    key: AAAAB3NzaC1yc2EAAAABIwAAAQEAyNoMftFLf3w0NOW7J0KUwOx9897CU352n3zKD3p/GCcdH4eMv1QI0BhjItZplWG8TzFSBfWOOSruRh1Gksa1l1jiQcisEio6Wr7kZ7bpvMMA45ZoaDc26HTB+r0BZkNn7Lwwxxvy+1pbqStnnKzb9OTYIyVkb495LS0x1EL/P9S/NWtpm8ZULa1JDplYMA5SqMZnhmlGAXdh8UnjdcdOgOm2ngA+geJBSzVbABECiIAklHU1PRzOtrq8SuO8JmXW6NkuL0aabdTgE6noIm+Nn7T5ufZpOpIGYimVI8+mu+efcBzAp5Q0vTRgSBLfggdczZbFfPXpIt1Ib+LEf+Cuqw==
             groups:
                 - gds
         tombooth:
             home_dir: /home/tombooth
             comment: Tom Booth
-            ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAABAQClJ8bE0B8OKPdCYNUxy28JQIzBVSBED0va9eERQ8I//YPChd/uo7x+736t5o41VNFJQXWOug3AKE8aV1qTPQn+33JUL/6OHtZDdec+lRzRXW4A+/8WMUoPDItygTB8dbMqRlg8rFDrwFKO6qZ3riHcwoj9BHAc4TlTbcq0vXgRRyHzc7uFwJzSd5wIY0nG5O7qbe4CubAij9hVfdHDS8GTMPuuqd7/YzOyjgKg72BDQWTF3u5YFECDtQgps8OZja59IlMM5L0QrZCVsJFlDtKYPRs6LcX6lEvt2ZBTfn6IPNzeNFJ1b8ltpjsEn/Yi70qA0XWq+kfLMccX4hau25kB
+            ssh_keys:
+                tombooth:
+                    key: AAAAB3NzaC1yc2EAAAADAQABAAABAQClJ8bE0B8OKPdCYNUxy28JQIzBVSBED0va9eERQ8I//YPChd/uo7x+736t5o41VNFJQXWOug3AKE8aV1qTPQn+33JUL/6OHtZDdec+lRzRXW4A+/8WMUoPDItygTB8dbMqRlg8rFDrwFKO6qZ3riHcwoj9BHAc4TlTbcq0vXgRRyHzc7uFwJzSd5wIY0nG5O7qbe4CubAij9hVfdHDS8GTMPuuqd7/YzOyjgKg72BDQWTF3u5YFECDtQgps8OZja59IlMM5L0QrZCVsJFlDtKYPRs6LcX6lEvt2ZBTfn6IPNzeNFJ1b8ltpjsEn/Yi70qA0XWq+kfLMccX4hau25kB
             groups:
                 - gds
         gkoth:


### PR DESCRIPTION
You are your key, or so they say...

Other than adding a specific naming convention e.g.

```
roc:
  ssh_keys:
    roc-default:
      key: KEY
```

I don't see a more mature/neat way of doing this, and I'm not sure the above makes any real difference either.
