### PR TITLE
Add keychain and setup for jenkins user

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -1,13 +1,13 @@
 classes:
-    - 'jenkins'
+    - 'performanceplatform::jenkins'
     - 'performanceplatform::deploy'
     - 'python'
     - 'nginx::server'
     - 'google_credentials'
     - 'phantomjs'
 
-jenkins::lts: 1
-jenkins::plugin_hash:
+performanceplatform::jenkins::lts: 1
+performanceplatform::jenkins::plugin_hash:
     git-client:
         version: "1.0.6"
     git:

--- a/modules/performanceplatform/files/jenkins-bashrc
+++ b/modules/performanceplatform/files/jenkins-bashrc
@@ -1,0 +1,7 @@
+#on this next line, we start keychain and point it to the private keys that
+#we'd like it to cache
+/usr/bin/keychain /var/lib/jenkins/.ssh/id_rsa
+
+# let the shell know ssh-agent
+source /var/lib/jenkins/.keychain/${HOSTNAME}-sh > /dev/null
+

--- a/modules/performanceplatform/manifests/deploy.pp
+++ b/modules/performanceplatform/manifests/deploy.pp
@@ -46,5 +46,12 @@ class performanceplatform::deploy (
             group   => 'jenkins',
             require => Class['jenkins'],
         }
+        file { '/var/lib/jenkins/.bashrc':
+          source  => 'puppet:///modules/performanceplatform/jenkins-bashrc',
+          owner   => 'jenkins',
+          group   => 'jenkins',
+          mode    => '0700',
+          require => Class['jenkins']
+        }
     }
 }

--- a/modules/performanceplatform/manifests/jenkins.pp
+++ b/modules/performanceplatform/manifests/jenkins.pp
@@ -13,12 +13,4 @@ class performanceplatform::jenkins(
     require => Class['::jenkins']
   }
 
-  file { '/var/lib/jenkins/.bashrc':
-    source  => 'puppet:///modules/performanceplatform/jenkins-bashrc',
-    owner   => 'jenkins',
-    group   => 'jenkins',
-    mode    => '0700',
-    require => Package['keychain']
-  }
-
 }

--- a/modules/performanceplatform/manifests/jenkins.pp
+++ b/modules/performanceplatform/manifests/jenkins.pp
@@ -1,0 +1,24 @@
+class performanceplatform::jenkins(
+  $lts,
+  $plugin_hash,
+) {
+
+  class { '::jenkins':
+    lts         => $lts,
+    plugin_hash => $plugin_hash,
+  }
+
+  package { 'keychain':
+    ensure  => installed,
+    require => Class['::jenkins']
+  }
+
+  file { '/var/lib/jenkins/.bashrc':
+    source  => 'puppet:///modules/performanceplatform/jenkins-bashrc',
+    owner   => 'jenkins',
+    group   => 'jenkins',
+    mode    => '0700',
+    require => Package['keychain']
+  }
+
+}


### PR DESCRIPTION
We've been having issues with ssh agent forwarding and jenkins, which we
need to push data between our environments. Keychain is what GOV.UK uses
to manage the agent forwarding so we should use it too.
