### PR TITLE
Change how nginx logs are tagged

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -42,4 +42,3 @@ nginx_conf:
 lumberjack_instances:
   nginx:
     log_files: [ '/var/log/nginx/*.access.json.log' ]
-    fields: { 'tag': 'nginx' }

--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -89,4 +89,3 @@ nginx_conf:
 lumberjack_instances:
     nginx:
         log_files: [ '/var/log/nginx/*.access.json.log' ]
-        fields: { "tag": "nginx" }

--- a/hieradata/role-monitoring.yaml
+++ b/hieradata/role-monitoring.yaml
@@ -73,4 +73,3 @@ nginx_conf:
 lumberjack_instances:
     nginx:
         log_files: [ '/var/log/nginx/*.access.json.log' ]
-        fields: { "tag": "nginx" }

--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -48,11 +48,6 @@ class performanceplatform::monitoring (
     ssl_key         => 'puppet:///modules/performanceplatform/logstash.key',
   }
 
-  logstash::filter::grep { 'tag-lumberjack':
-    type    => 'lumberjack',
-    add_tag => [ "%{tag}" ],
-  }
-
   logstash::filter::mutate { 'nginx-token-fix':
     type => 'lumberjack',
     tags => [ 'nginx' ],

--- a/modules/performanceplatform/templates/nginx.logging.conf.erb
+++ b/modules/performanceplatform/templates/nginx.logging.conf.erb
@@ -1,5 +1,6 @@
 
 log_format json_event '{ "@timestamp": "$time_iso8601", '
+                        '"@tags": [ "nginx" ], '
                         '"@fields": { '
                         '"remote_addr": "$remote_addr", '
                         '"remote_user": "$remote_user", '


### PR DESCRIPTION
We have moved defining the nginx tags into it's log format rather than
using a grep filter in logstash as this was not scaling to other log
types.
