### PR TITLE
Sending varnish logs to logstash

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -42,3 +42,5 @@ nginx_conf:
 lumberjack_instances:
   nginx:
     log_files: [ '/var/log/nginx/*.access.json.log' ]
+  varnish:
+    log_files: [ '/var/log/varnish/varnishncsa.log' ]

--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -48,6 +48,12 @@ class performanceplatform::monitoring (
     ssl_key         => 'puppet:///modules/performanceplatform/logstash.key',
   }
 
+  logstash::filter::date { 'varnish-timestamp-fix':
+    type  => 'lumberjack',
+    tags  => [ 'varnish' ],
+    match => [ 'timestamp', 'dd/MMM/YYYY:HH:mm:ss' ],
+  }
+
   logstash::filter::mutate { 'nginx-token-fix':
     type => 'lumberjack',
     tags => [ 'nginx' ],

--- a/modules/varnish/files/etc/default/varnishncsa
+++ b/modules/varnish/files/etc/default/varnishncsa
@@ -6,3 +6,8 @@
 #
 # NCSA log format, to be used by HTTP log analyzers
 VARNISHNCSA_ENABLED=1
+#
+# Varnish log format
+VARNISH_LOG_FORMAT='{"@tags":["varnish"],"@fields":{"timestamp":"%t","remote_addr":"%h","remote_user":"%u","x_forwarded_for":"%{X-Forwarded-For}i","hit_miss":"%{Varnish:hitmiss}x","body_bytes_sent":"%b","request_time":"%{Varnish:time_firstbyte}x","status":"%s","request":"%r","host":"%{host}i","request_method":"%m","time_first_byte":"%{Varnish:time_firstbyte}x","handling":"%{Varnish:handling}x","http_referrer":"%{Referrer}i","http_user_agent":"%{User-agent}i"}}'
+
+DAEMON_OPTS="${DAEMON_OPTS} -F ${VARNISH_LOG_FORMAT}"

--- a/modules/varnish/templates/defaults.erb
+++ b/modules/varnish/templates/defaults.erb
@@ -61,6 +61,7 @@ VARNISH_STORAGE="malloc,${VARNISH_STORAGE_SIZE}"
 #
 # # Default TTL used when the backend does not specify one
 VARNISH_TTL=<%= scope.lookupvar('varnish::default_ttl') %>
+
 #
 # # DAEMON_OPTS is used by the init script.  If you add or remove options, make
 # # sure you update this section, too.


### PR DESCRIPTION
Formatted varnish log output to logstash JSON format. Also had to setup
a filter to convert varnish timestamp to iso8601. The version of varnish
we are using (3.2) doesn't support specifying a time format and 3.4
hasn't been released yet.

Lumberjack ships the logs to logstash.
