### PR TITLE
Output logstash to elasticsearch

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -134,7 +134,7 @@ performanceplatform::dns::hosts: |
     172.27.1.31 mongo-1 mongo
     172.27.1.32 mongo-2 mongo
     172.27.1.33 mongo-3 mongo
-    172.27.1.41 monitoring-1 log logging graphite logstash alerts redis rabbitmq
+    172.27.1.41 monitoring-1 log logging graphite logstash alerts redis rabbitmq elasticsearch
 
 performanceplatform::mongo::mongo_hosts:
     - mongo-1

--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -76,9 +76,9 @@ vhost_proxies:
     elasticsearch-vhost:
         servername:      "%{::elasticsearch_vhost}"
         port:            9200
-        upstream_server: 'logging'
+        upstream_server: 'elasticsearch'
         upstream_port:   9200
-        proxy_magic:     'limit_except GET HEAD OPTIONS { deny all; }'
+        proxy_magic:     'limit_except GET POST HEAD OPTIONS { deny all; }'
         access_logs:
             '{name}.access.log.json': 'json_event'
 

--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -73,10 +73,8 @@ class performanceplatform::monitoring (
     namespace => 'nginx',
   }
 
-  # Uncomment for testing
-  # logstash::output::file { 'test':
-  #   tags => ['tag-to-filter'],
-  #   path => '/var/log/temp.test.delete.me.log.json'
-  # }
+  logstash::output::elasticsearch { 'elasticsearch':
+    host => 'elasticsearch',
+  }
 
 }


### PR DESCRIPTION
Allowed POST on elasticsearch to enable searching. DELETE is still
disabled, so the worst it can happens is insert extra logs.
Also added elasticsearch for internal DNS so it decouples the service
from the server.
