### PR TITLE
Extend server_bucket_hash_size for jumpbox

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -7,6 +7,8 @@ classes:
     - 'google_credentials'
     - 'phantomjs'
 
+nginx::server::server_names_hash_bucket_size: 128
+
 performanceplatform::jenkins::lts: 1
 performanceplatform::jenkins::plugin_hash:
     git-client:


### PR DESCRIPTION
Our monitoring domains are getting a bit too long now so we need to bump
with up. Boo for going over bus width
