### PR TITLE
Increase logstash min and max memory

### DIFF
--- a/hieradata/role-monitoring.yaml
+++ b/hieradata/role-monitoring.yaml
@@ -32,6 +32,8 @@ sensu::server: true
 logstash::java_install: true
 logstash::provider: 'custom'
 logstash::jarfile: 'puppet:///modules/performanceplatform/logstash-1.1.13-monolithic.jar'
+logstash::defaultsfiles:
+    agent: 'puppet:///modules/performanceplatform/etc/sysconfig/logstash.defaults'
 
 ufw_rules:
     allowcarbonfromanywhere:

--- a/modules/performanceplatform/files/etc/sysconfig/logstash.defaults
+++ b/modules/performanceplatform/files/etc/sysconfig/logstash.defaults
@@ -1,0 +1,14 @@
+# Start logstash
+START=true
+
+# Java options
+LS_JAVA_OPTS="${LS_JAVA_OPTS} -Xms512m -Xmx512m"
+
+# Open files limit
+#OPEN_FILES=2049
+
+# Nice setting
+#NICE=19
+
+# Number of filter threads ( default 1 )
+#FILTER_THREADS=1


### PR DESCRIPTION
Logstash was failing with a Java out of memory error. This is not a
final solution, there is a story in the backlog to review how we're
running logstash.
