### PR TITLE
Add local cname for www fqdn

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -137,6 +137,9 @@ performanceplatform::dns::hosts: |
     172.27.1.33 mongo-3 mongo
     172.27.1.41 monitoring-1 log logging graphite logstash alerts redis rabbitmq elasticsearch
 
+performanceplatform::dns::cnames:
+    - [ "%{::www_vhost}", "frontend" ]
+
 performanceplatform::mongo::mongo_hosts:
     - mongo-1
     - mongo-2

--- a/modules/performanceplatform/manifests/dns.pp
+++ b/modules/performanceplatform/manifests/dns.pp
@@ -1,12 +1,13 @@
-class performanceplatform::dns {
+class performanceplatform::dns (
+  $aliases = [],
+  $cnames  = [],
+  $hosts   = '',
+) {
 
   include dnsmasq
 
-  $aliases = hiera('performanceplatform::dns::aliases', {})
-  validate_hash($aliases)
-  $cnames = hiera('performanceplatform::dns::cnames', {})
-  validate_hash($cnames)
-  $hosts = hiera('performanceplatform::dns::hosts', '')
+  validate_array($aliases)
+  validate_array($cnames)
 
   dnsmasq::conf { 'internal-dns':
       ensure  => present,

--- a/modules/performanceplatform/templates/internal-dns.erb
+++ b/modules/performanceplatform/templates/internal-dns.erb
@@ -13,11 +13,11 @@ strict-order
 addn-hosts=/etc/hosts.dns
 
 # alias external IPs to local IPs
-<%- @aliases.each do |src, dst| -%>
-alias=<%= src %>,<%= dst %>
+<%- @aliases.each do |pair| -%>
+alias=<%= pair[0] %>,<%= pair[1] %>
 <%- end -%>
 
 # cname apps and other vhosts to node roles
-<%- @cnames.each do |src, dst| -%>
-cname=<%= src %>,<%= dst %>
+<%- @cnames.each do |pair| -%>
+cname=<%= pair[0] %>,<%= pair[1] %>
 <%- end -%>


### PR DESCRIPTION
Collectors and the smoke tests use the www fqdn to talk to services
inside of the infrastructure. Skyscape does not like us doing this and
has locked it down. So that these can still operate we have internal dns
to round robin route the fqdn to the frontend servers as the load
balancers would
