### PR TITLE
Elasticsearch should store data in new mount

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -3,7 +3,6 @@ forge "http://forge.puppetlabs.com"
 mod 'attachmentgenie/ssh',        '1.1.0'
 mod 'attachmentgenie/ufw',        '1.2.0'
 mod 'dwerder/graphite',           '3.0.1'
-mod 'gdsoperations/elasticsearch','0.0.1'
 mod 'pdxcat/collectd',            '0.0.4'
 mod 'puppetlabs/gcc',             '0.0.3'
 mod 'puppetlabs/nodejs',          '0.4.0'
@@ -16,39 +15,41 @@ mod 'saz/rsyslog',                '2.0.0'
 mod 'smarchive/archive',          '0.1.1'
 mod 'thomasvandoren/redis',       '0.0.9'
 mod 'netmanagers/fail2ban',       '1.1.0'
-mod 'account',    :git => 'https://github.com/alphagov/puppet-account.git',
-                  :ref => 'feature/multiple-ssh-keys'
-mod 'clamav',     :git => 'git://github.com/alphagov/puppet-clamav.git',
-                  :ref => '31af4f0c2753dd25bca3dd0c7cc69d273c4d640d'
-mod 'collectd',   :git => 'git://github.com/alphagov/puppet-collectd.git',
-                  :ref => 'e17cb3f06f5e26299de145da8fe18a218a10f3c4'
-mod 'curl',       :git => 'git://github.com/alphagov/puppet-curl.git',
-                  :ref => 'f4c6d175bdc6cbd71f71fbaa2544ef8f70c4ce48'
-mod 'ext4mount',  :git => 'git://github.com/alphagov/puppet-ext4mount.git',
-                  :ref => 'd97f99cc2801b83152b905d1285fa34e689cb499'
-mod 'gstatsd',    :git => 'git://github.com/alphagov/puppet-gstatsd.git',
-                  :ref => 'c7eb9b99c34194d92e9e8494bdeed1b29b43ed60'
-mod 'harden',     :git => 'git://github.com/alphagov/puppet-harden.git',
-                  :ref => '0966c98cc3f54815c9aac0ebe6e900b70f85182d'
-mod 'jenkins',    :git => 'git://github.com/alphagov/puppet-jenkins.git',
-                  :ref => '4c7990fa8495b6d84292c2153993ac91c3b2916d'
-mod 'logstash',   :git => 'git://github.com/alphagov/puppet-logstash.git',
-                  :ref => 'gen-files-should-notify'
-mod 'lumberjack', :git => 'git://github.com/alphagov/puppet-lumberjack.git',
-                  :ref => 'develop'
-mod 'mongodb',    :git => 'git://github.com/alphagov/puppetlabs-mongodb.git',
-                  :ref => 'dc077a209efdf8d80fac40d40fec575b6a0949d2'
-mod 'nginx',      :git => 'git://github.com/alphagov/puppet-nginx.git',
-                  :ref => 'e60b12ddfbf22862ad0fdcc12056b5c5f3089795'
-mod 'python',     :git => 'git://github.com/stankevich/puppet-python.git',
-                  :ref => 'f508b71d534f3c67db12886fa914cb4ef74bbe7a'
-mod 'sensu',      :git => 'git://github.com/alphagov/sensu-puppet.git',
-                  :ref => 'fix-check-deps'
-mod 'ssl',        :git => 'git://github.com/alphagov/puppet-ssl.git',
-                  :ref => '23bbb5ab57f26269acce3d4b43e643781747a551'
-mod 'upstart',    :git => 'git://github.com/bison/puppet-upstart.git',
-                  :ref => '05a10a3a58de3543eb51bb782a249cebf71f5cd8'
-mod 'tmux',       :git => 'git://github.com/endore-me/puppet-tmux.git',
-                  :ref => '32db4ac6ad65a934c5eddd9afcf0c4f61f7c0924'
+mod 'account',       :git => 'https://github.com/alphagov/puppet-account.git',
+                     :ref => 'feature/multiple-ssh-keys'
+mod 'clamav',        :git => 'git://github.com/alphagov/puppet-clamav.git',
+                     :ref => '31af4f0c2753dd25bca3dd0c7cc69d273c4d640d'
+mod 'collectd',      :git => 'git://github.com/alphagov/puppet-collectd.git',
+                     :ref => 'e17cb3f06f5e26299de145da8fe18a218a10f3c4'
+mod 'curl',          :git => 'git://github.com/alphagov/puppet-curl.git',
+                     :ref => 'f4c6d175bdc6cbd71f71fbaa2544ef8f70c4ce48'
+mod 'elasticsearch', :git => 'git://github.com/gds-operations/puppet-elasticsearch.git',
+                     :ref => 'd15521e6cb215a809d92692e76a1d0cac111d9a0'
+mod 'ext4mount',     :git => 'git://github.com/alphagov/puppet-ext4mount.git',
+                     :ref => 'd97f99cc2801b83152b905d1285fa34e689cb499'
+mod 'gstatsd',       :git => 'git://github.com/alphagov/puppet-gstatsd.git',
+                     :ref => 'c7eb9b99c34194d92e9e8494bdeed1b29b43ed60'
+mod 'harden',        :git => 'git://github.com/alphagov/puppet-harden.git',
+                     :ref => '0966c98cc3f54815c9aac0ebe6e900b70f85182d'
+mod 'jenkins',       :git => 'git://github.com/alphagov/puppet-jenkins.git',
+                     :ref => '4c7990fa8495b6d84292c2153993ac91c3b2916d'
+mod 'logstash',      :git => 'git://github.com/alphagov/puppet-logstash.git',
+                     :ref => 'gen-files-should-notify'
+mod 'lumberjack',    :git => 'git://github.com/alphagov/puppet-lumberjack.git',
+                     :ref => 'develop'
+mod 'mongodb',       :git => 'git://github.com/alphagov/puppetlabs-mongodb.git',
+                     :ref => 'dc077a209efdf8d80fac40d40fec575b6a0949d2'
+mod 'nginx',         :git => 'git://github.com/alphagov/puppet-nginx.git',
+                     :ref => 'e60b12ddfbf22862ad0fdcc12056b5c5f3089795'
+mod 'python',        :git => 'git://github.com/stankevich/puppet-python.git',
+                     :ref => 'f508b71d534f3c67db12886fa914cb4ef74bbe7a'
+mod 'sensu',         :git => 'git://github.com/alphagov/sensu-puppet.git',
+                     :ref => 'fix-check-deps'
+mod 'ssl',           :git => 'git://github.com/alphagov/puppet-ssl.git',
+                     :ref => '23bbb5ab57f26269acce3d4b43e643781747a551'
+mod 'upstart',       :git => 'git://github.com/bison/puppet-upstart.git',
+                     :ref => '05a10a3a58de3543eb51bb782a249cebf71f5cd8'
+mod 'tmux',          :git => 'git://github.com/endore-me/puppet-tmux.git',
+                     :ref => '32db4ac6ad65a934c5eddd9afcf0c4f61f7c0924'
 mod 'google_credentials', :git => 'git://github.com/alphagov/puppet-google_credentials.git',
                           :ref => 'a64f9e5c051a0d38e59441457b52a7afeeebed24'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -14,8 +14,6 @@ FORGE
       puppetlabs/apt (>= 0.0.0)
       puppetlabs/stdlib (>= 0.0.0)
       stahnma/epel (>= 0.0.0)
-    gdsoperations/elasticsearch (0.0.1)
-      puppetlabs/stdlib (>= 3.0.0)
     maestrodev/wget (1.2.2)
     netmanagers/fail2ban (1.1.0)
       example42/monitor (>= 2.0.0)
@@ -167,6 +165,14 @@ GIT
     tmux (0.0.1)
 
 GIT
+  remote: git://github.com/gds-operations/puppet-elasticsearch.git
+  ref: d15521e6cb215a809d92692e76a1d0cac111d9a0
+  sha: d15521e6cb215a809d92692e76a1d0cac111d9a0
+  specs:
+    elasticsearch (0.0.1)
+      puppetlabs/stdlib (>= 3.0.0)
+
+GIT
   remote: git://github.com/stankevich/puppet-python.git
   ref: f508b71d534f3c67db12886fa914cb4ef74bbe7a
   sha: f508b71d534f3c67db12886fa914cb4ef74bbe7a
@@ -188,8 +194,8 @@ DEPENDENCIES
   collectd (>= 0)
   curl (>= 0)
   dwerder/graphite (= 3.0.1)
+  elasticsearch (>= 0)
   ext4mount (>= 0)
-  gdsoperations/elasticsearch (= 0.0.1)
   google_credentials (>= 0)
   gstatsd (>= 0)
   harden (>= 0)

--- a/hieradata/role-monitoring.yaml
+++ b/hieradata/role-monitoring.yaml
@@ -7,7 +7,6 @@ classes:
     - 'performanceplatform::monitoring'
     - 'rabbitmq'
     - 'redis'
-    - 'performanceplatform::elasticsearch'
     - 'performanceplatform::server_checking'
 
 performanceplatform::server_checking::boxes:

--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -1,5 +1,10 @@
-class performanceplatform::elasticsearch {
-  include ::elasticsearch
+class performanceplatform::elasticsearch(
+  $data_directory,
+) {
+
+  class { '::elasticsearch':
+    data_directory => '/mnt/data/elasticsearch',
+  }
 
   cron {'elasticsearch-rotate-indices':
     ensure  => present,

--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -1,9 +1,21 @@
 class performanceplatform::monitoring (
 ) {
 
-  ext4mount { '/mnt/data/elasticsearch':
+  $elasticsearch_data_dir = '/mnt/data/elasticsearch'
+
+  file { '/mnt/data':
+    ensure => directory,
+  }
+
+  performanceplatform::mount { $elasticsearch_data_dir:
     mountoptions => 'defaults',
     disk         => '/dev/mapper/data-elasticsearch',
+    require      => File['/mnt/data'],
+  }
+
+  class { 'performanceplatform::elasticsearch':
+    data_directory => $elasticsearch_data_dir,
+    require        => Performanceplatform::Mount[$elasticsearch_data_dir],
   }
 
   file { '/etc/apache2/run':

--- a/modules/performanceplatform/manifests/mount.pp
+++ b/modules/performanceplatform/manifests/mount.pp
@@ -1,0 +1,19 @@
+define performanceplatform::mount(
+  $mountoptions,
+  $disk,
+) {
+
+  if hiera('environment') == 'development' {
+
+    ensure_resource('file', $title, { 'ensure' => 'directory' })
+
+  } else {
+
+    ext4mount { $title:
+      mountoptions => 'defaults',
+      disk         => '/dev/mapper/data-elasticsearch',
+    }
+
+  }
+
+}


### PR DESCRIPTION
Add parameter to puppet-elasticsearch and switched to using the latest
commit in our Puppetfile (all the noise is around that change).

Moved defining elasticsearch class into monitoring class as I didn't
want to have the mounted directory hardcoded in two places.

Added a mount resource so that we can avoid trying to mount a disk that
isn't there when provisioning on vagrant (environment=development).
