### PR TITLE
Make the checks better

### DIFF
--- a/modules/performanceplatform/manifests/mongo.pp
+++ b/modules/performanceplatform/manifests/mongo.pp
@@ -57,7 +57,7 @@ rs.initiate(replicaSetConfig());
     $escaped_fqdn = regsubst($fqdn, '\.', '_', 'G')
 
     sensu::check { "mongod_is_down_$escaped_fqdn":
-      command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p mongod',
+      command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p mongod -W 1 -C 1',
       interval => '60',
       handlers => 'pagerduty',
     }

--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -112,7 +112,7 @@ class performanceplatform::monitoring (
   }
 
   sensu::check { 'logstash_is_down':
-    command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -f /var/run/logstash-agent.pid',
+    command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p logstash -W 1 -C 1',
     interval => '60',
     handlers => 'pagerduty',
   }


### PR DESCRIPTION
PID file use in the logstash check cause it to fail by the check blowing
up, so I switched it for a grepping.

Neither of them were actually defining how many process should be
running. They will all now critical on less than 1.
