### PR TITLE
[Spotlight] Set NODE_ENV to the be actual env

### DIFF
--- a/modules/spotlight/manifests/app.pp
+++ b/modules/spotlight/manifests/app.pp
@@ -17,7 +17,7 @@ class spotlight::app (
     servername   => $::spotlight_vhost,
     proxy_ssl    => true,
     extra_env    => {
-      'NODE_ENV' => 'production',
+      'NODE_ENV' => $::environment,
     },
     upstart_desc => 'Spotlight job',
     upstart_exec => 'node app/server.js',


### PR DESCRIPTION
- development
- preview
- staging
- production

I'm unclear why when I run `vagrant provision frontend-app-1` I get a resulting job including `env NODE_ENV=production`. I'd expect `development`.
