### PR TITLE
Add in env_hosts to dns.pp

### DIFF
--- a/modules/performanceplatform/manifests/dns.pp
+++ b/modules/performanceplatform/manifests/dns.pp
@@ -1,7 +1,8 @@
 class performanceplatform::dns (
-  $aliases = [],
-  $cnames  = [],
-  $hosts   = '',
+  $aliases    = [],
+  $cnames     = [],
+  $hosts      = '',
+  $env_hosts  = '',
 ) {
 
   include dnsmasq
@@ -15,7 +16,7 @@ class performanceplatform::dns (
   }
 
   file { '/etc/hosts.dns':
-      content => $hosts,
+      content => "${hosts}\n${env_hosts}",
       notify  => Class['dnsmasq::service'],
   }
 


### PR DESCRIPTION
- Allows us to pass through specific environment hosts
- This is necessary to switch to staging from production with e.g. signon
