### PR TITLE
Graphite checks should stick to the interval given

### DIFF
--- a/modules/performanceplatform/manifests/graphite_check.pp
+++ b/modules/performanceplatform/manifests/graphite_check.pp
@@ -17,11 +17,11 @@ define performanceplatform::graphite_check(
   }
 
   sensu::check { $name:
-    command  => "${check_data_path} ${server_config} ${flags} -t \"${target}\" -w \"${warning}\" -c \"${critical}\" -n \"${name}\"",
+    command  => "${check_data_path} ${server_config} ${flags} --age ${interval} -t \"${target}\" -w \"${warning}\" -c \"${critical}\" -n \"${name}\"",
     interval => $interval,
     handlers => $handlers,
     custom   => {
-      graphite_url => "https://${::graphite_vhost}/render?target=${target}&from=-10min",
+      graphite_url => "https://${::graphite_vhost}/render?target=${target}&from=-${interval}s",
     },
   }
 }


### PR DESCRIPTION
I have set the allowed graphite change of the ruby data check to the
interval length and the amount of time we look back through graphite
also to the interval length.
