### PR TITLE
Make the intervals for checks more reasonable

### DIFF
--- a/modules/performanceplatform/manifests/graphite_check.pp
+++ b/modules/performanceplatform/manifests/graphite_check.pp
@@ -2,7 +2,7 @@ define performanceplatform::graphite_check(
   $target,
   $warning,
   $critical,
-  $interval = '60',
+  $interval = 60,
   $handlers = undef,
   $ignore_no_data = false,
 ) {
@@ -16,8 +16,10 @@ define performanceplatform::graphite_check(
     $flags = ''
   }
 
+  $max_age = $interval * 2
+
   sensu::check { $name:
-    command  => "${check_data_path} ${server_config} ${flags} --age ${interval} -t \"${target}\" -w \"${warning}\" -c \"${critical}\" -n \"${name}\"",
+    command  => "${check_data_path} ${server_config} ${flags} --age ${max_age} -t \"${target}\" -w \"${warning}\" -c \"${critical}\" -n \"${name}\"",
     interval => $interval,
     handlers => $handlers,
     custom   => {

--- a/modules/performanceplatform/manifests/mongo.pp
+++ b/modules/performanceplatform/manifests/mongo.pp
@@ -58,7 +58,7 @@ rs.initiate(replicaSetConfig());
 
     sensu::check { "mongod_is_down_$escaped_fqdn":
       command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p mongod -W 1 -C 1',
-      interval => '60',
+      interval => 60,
       handlers => 'pagerduty',
     }
 

--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -113,7 +113,7 @@ class performanceplatform::monitoring (
 
   sensu::check { 'logstash_is_down':
     command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p logstash -W 1 -C 1',
-    interval => '60',
+    interval => 60,
     handlers => 'pagerduty',
   }
 
@@ -123,7 +123,7 @@ class performanceplatform::monitoring (
     target   => "collectd.${graphite_fqdn}.df-mnt-data-elasticsearch.df_complex-free",
     warning  => '4000000000:', # A little less than 4 gig
     critical => '1000000000:',  # A little less than 1 gig
-    interval => '60',
+    interval => 60,
     handlers => 'pagerduty',
   }
 

--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -34,7 +34,7 @@ define performanceplatform::proxy_vhost(
       target         => "sumSeries(stats.nginx.${::hostname}.${graphite_servername}.http_5*)",
       warning        => $five_warning,
       critical       => $five_critical,
-      interval       => '10',
+      interval       => 60,
       ignore_no_data => true,
     }
 
@@ -42,7 +42,7 @@ define performanceplatform::proxy_vhost(
       target   => "sumSeries(stats.nginx.${::hostname}.${graphite_servername}.http_4*)",
       warning  => $four_warning,
       critical => $four_critical,
-      interval => '10',
+      interval => 60,
       ignore_no_data => true,
     }
   }

--- a/modules/performanceplatform/manifests/server_checks.pp
+++ b/modules/performanceplatform/manifests/server_checks.pp
@@ -8,14 +8,14 @@ define performanceplatform::server_checks(
       target   => "collectd.${graphite_fqdn}.cpu-0.cpu-idle",
       warning  => '20:',
       critical => '5:',
-      interval => '10',
+      interval => 60,
     }
 
     performanceplatform::graphite_check { "check_low_disk_space_${name}":
       target   => "collectd.${graphite_fqdn}.df-root.df_complex-free",
       warning  => '4000000000:', # A little less than 4 gig
       critical => '1000000000:',  # A little less than 1 gig
-      interval => '10',
+      interval => 60,
       handlers => 'pagerduty',
     }
 
@@ -23,7 +23,7 @@ define performanceplatform::server_checks(
       target   => "transformNull(collectd.${graphite_fqdn}.uptime.uptime)",
       warning  => '0:',
       critical => '0:',
-      interval => '1',
+      interval => 60,
       handlers => 'pagerduty',
     }
 }


### PR DESCRIPTION
10s and 1s were a bit quick, 60s is more appropriate.

I doubled the interval to make the max_age for graphite check as
graphite will sometimes return data outside of the time span you have
given. This was causing checks to fire when data breached the max_age
