### PR TITLE
Smoke tests should alert us through pagerduty

### DIFF
--- a/modules/performanceplatform/manifests/backdrop_smoke_tests.pp
+++ b/modules/performanceplatform/manifests/backdrop_smoke_tests.pp
@@ -19,6 +19,7 @@ class performanceplatform::backdrop_smoke_tests (
 
     sensu::check { 'backdrop_smoke_tests':
       interval => 120,
-      command  => "ruby ${check_data_path}  -u 'https://${www_vhost}/test' -b'${test_bucket_token}'"
+      command  => "ruby ${check_data_path}  -u 'https://${www_vhost}/test' -b'${test_bucket_token}'",
+      handlers => 'pagerduty',
     }
 }


### PR DESCRIPTION
Because it is important to know when backdrop is down
