### PR TITLE
Raise priority of environment (!?)

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,7 +1,7 @@
 :hierarchy:
+    - environment
     - "role-%{::machine_role}"
     - secrets
-    - environment
     - common
 :backends:
     - yaml


### PR DESCRIPTION
WARNING: I am not sure about this.

_Issue_: we are defining `logstash::defaultsfiles` in both the `role-monitoring.yaml` file and in our `environment.yaml` specific files. Based on the hiera hierachy, we will never take into account our environment specific setting.

_Resolution_: I've switched the hierarchy so environment specific variables take precedence over the roles. Let me know if that is a terrible idea.
