### PR TITLE
Improve 4xx checks

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -25,6 +25,11 @@ vhost_proxies:
     upstream_port: 7999
     access_logs:
       '{name}.access.log.json': 'json_event'
+    four_warning: 1
+    four_critical: 3
+    five_warning: 0
+    five_critical: 1
+
   www-vhost:
     servername:    "%{::www_vhost}"
     ssl:           true
@@ -32,6 +37,10 @@ vhost_proxies:
     upstream_port: 7999
     access_logs:
       '{name}.access.log.json': 'json_event'
+    four_warning: 1
+    four_critical: 3
+    five_warning: 0
+    five_critical: 1
 
 nginx::server::server_names_hash_bucket_size: 128
 

--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -31,7 +31,7 @@ define performanceplatform::proxy_vhost(
 
   if $sensu_check {
     performanceplatform::graphite_check { "5xx_rate_${servername}":
-      target         => "sumSeries(stats.nginx.${::hostname}.${graphite_servername}.http_5*)",
+      target         => "movingAverage(sumSeries(stats.nginx.${::hostname}.${graphite_servername}.http_5*), 60)",
       warning        => $five_warning,
       critical       => $five_critical,
       interval       => 60,
@@ -39,7 +39,7 @@ define performanceplatform::proxy_vhost(
     }
 
     performanceplatform::graphite_check { "4xx_rate_${servername}":
-      target         => "sumSeries(stats.nginx.${::hostname}.${graphite_servername}.http_4*)",
+      target         => "movingAverage(sumSeries(stats.nginx.${::hostname}.${graphite_servername}.http_4*), 60)",
       warning        => $four_warning,
       critical       => $four_critical,
       interval       => 60,


### PR DESCRIPTION
- Add  a `movingAverage` function to the graphite URLs. The checks run every 60 seconds but only look at the most recent data point.
- Relax the limits to prevent the alerts firing continuously.
