### PR TITLE
Add in a tag and push it

### DIFF
--- a/tools/build
+++ b/tools/build
@@ -38,7 +38,7 @@ main () {
   tar zcf build/puppet.tgz -X .buildignore .
 
   status "Writing build tag"
-  git tag -a build_$BUILD_TAG -m "$BUILD_URL"
+  git tag -a build_$BUILD_NUMBER -m "$BUILD_URL"
   git push --follow-tags
 
 }

--- a/tools/build
+++ b/tools/build
@@ -36,6 +36,11 @@ main () {
   test -d build || mkdir build
   status "creating tarball at puppet.tgz"
   tar zcf build/puppet.tgz -X .buildignore .
+
+  status "Writing build tag"
+  git tag -a build_$BUILD_TAG -m "$BUILD_URL"
+  git push --follow-tags
+
 }
 
 main


### PR DESCRIPTION
We haven't been tagging our releases

![](http://www.reactiongifs.com/wp-content/uploads/2013/11/stoners.gif)
- Currently when building from production we need to go to ci-new to check for a build tag.
- It would be cool if we could get the tag reference from the repo on github
- Tagging: inherently good for rollbacks etc
