### PR TITLE
Use fqdn for graphite check

### DIFF
--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -27,11 +27,12 @@ define performanceplatform::proxy_vhost(
   $sensu_check          = true,
 ) {
 
+  $graphite_fqdn = regsubst($::fqdn, '\.', '_', 'G')
   $graphite_servername = regsubst($servername, '\.', '_', 'G')
 
   if $sensu_check {
     performanceplatform::graphite_check { "5xx_rate_${servername}":
-      target         => "sumSeries(stats.nginx.${::hostname}.${graphite_servername}.http_5*)",
+      target         => "sumSeries(stats.nginx.${graphite_fqdn}.${graphite_servername}.http_5*)",
       warning        => $five_warning,
       critical       => $five_critical,
       interval       => 60,
@@ -39,7 +40,7 @@ define performanceplatform::proxy_vhost(
     }
 
     performanceplatform::graphite_check { "4xx_rate_${servername}":
-      target         => "sumSeries(stats.nginx.${::hostname}.${graphite_servername}.http_4*)",
+      target         => "sumSeries(stats.nginx.${graphite_fqdn}.${graphite_servername}.http_4*)",
       warning        => $four_warning,
       critical       => $four_critical,
       interval       => 60,


### PR DESCRIPTION
Logstash uses @server_name when sending to graphite. This has the
`_localdomain` suffix.
