### PR TITLE
Reduce frequency of app _status checks

### DIFF
--- a/modules/performanceplatform/manifests/backdrop_checks.pp
+++ b/modules/performanceplatform/manifests/backdrop_checks.pp
@@ -3,6 +3,7 @@ class performanceplatform::backdrop_checks (
     $check_data_path = '/etc/sensu/community-plugins/plugins/http/check-http.rb'
 
     sensu::check { "a_backdrop_health_check":
+      interval => 120,
       command  => "${check_data_path}  -u http://localhost/_status",
     }
 }

--- a/modules/performanceplatform/manifests/spotlight_checks.pp
+++ b/modules/performanceplatform/manifests/spotlight_checks.pp
@@ -2,7 +2,8 @@ class performanceplatform::spotlight_checks () {
   $check_http_path = '/etc/sensu/community-plugins/plugins/http/check-http.rb'
 
   sensu::check { 'spotlight_status_check':
-    require => Class['Spotlight::App'],
-    command => "${check_http_path} -u http://localhost:${spotlight::app::port}/_status",
+    require  => Class['Spotlight::App'],
+    command  => "${check_http_path} -u http://localhost:${spotlight::app::port}/_status",
+    interval => 120,
   }
 }


### PR DESCRIPTION
We are firing a _status request off on apps every second. This is a bit
much.
