### PR TITLE
Add screenshot-as-a-service app

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -1,6 +1,7 @@
 ---
 classes:
   - 'nginx::server'
+  - 'phantomjs'
   - 'spotlight::app'
   - 'varnish'
 

--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -2,8 +2,16 @@
 classes:
   - 'nginx::server'
   - 'phantomjs'
+  - 'screenshot_as_a_service::app'
   - 'spotlight::app'
   - 'varnish'
+
+# screenshot_as_a_service runs on 3059 and 3060, but 3059
+# is only used from within this app.
+screenshot_as_a_service::app::port:       3060
+screenshot_as_a_service::app::app_module: 'screenshot_as_a_service:app'
+screenshot_as_a_service::app::user:       'deploy'
+screenshot_as_a_service::app::group:      'deploy'
 
 spotlight::app::port:       3057
 spotlight::app::app_module: 'spotlight:app'

--- a/manifests/nodes.pp
+++ b/manifests/nodes.pp
@@ -18,6 +18,7 @@ $logging_vhost       = join(['logging',$domain_name],'.')
 $alerts_vhost        = join(['alerts',$domain_name],'.')
 $www_vhost           = join(['www',$public_domain_name],'.')
 $spotlight_vhost     = join(['spotlight',$public_domain_name],'.')
+$screenshot_as_a_service_vhost = join(['screenshot', $public_domain_name], '.')
 
 $rabbitmq_sensu_password = hiera('rabbitmq_sensu_password')
 

--- a/modules/screenshot_as_a_service/manifests/app.pp
+++ b/modules/screenshot_as_a_service/manifests/app.pp
@@ -1,0 +1,24 @@
+class screenshot_as_a_service::app (
+  $port       = undef,
+  $workers    = 4,
+  $app_module = undef,
+  $user       = undef,
+  $group      = undef,
+) {
+  include performanceplatform::nodejs
+
+  performanceplatform::app { 'screenshot_as_a_service':
+    port         => $port,
+    workers      => $workers,
+    app_module   => $app_module,
+    user         => $user,
+    group        => $group,
+    servername   => $::screenshot_as_a_service_vhost,
+    proxy_ssl    => true,
+    extra_env    => {
+      'NODE_ENV' => $::pp_environment,
+    },
+    upstart_desc => 'Screenshot as a service job',
+    upstart_exec => 'node app.js',
+  }
+}

--- a/modules/screenshot_as_a_service/manifests/app.pp
+++ b/modules/screenshot_as_a_service/manifests/app.pp
@@ -16,7 +16,7 @@ class screenshot_as_a_service::app (
     servername   => $::screenshot_as_a_service_vhost,
     proxy_ssl    => true,
     extra_env    => {
-      'NODE_ENV' => $::pp_environment,
+      'NODE_ENV' => 'production',
     },
     upstart_desc => 'Screenshot as a service job',
     upstart_exec => 'node app.js',

--- a/modules/screenshot_as_a_service/manifests/init.pp
+++ b/modules/screenshot_as_a_service/manifests/init.pp
@@ -1,0 +1,3 @@
+class screenshot_as_a_service() {
+  # empty class for screenshot_as_a_service
+}


### PR DESCRIPTION
App to run on the frontend app servers that can be called by Spotlight to create fallback images.
