### PR TITLE
Remove writing to /etc/hostname

### DIFF
--- a/manifests/nodes.pp
+++ b/manifests/nodes.pp
@@ -27,14 +27,6 @@ $pp_environment = hiera('pp_environment')
 hiera_include('classes')
 
 node default {
-  # Make sure /etc/hostname has the correct hostname in
-  file { "/etc/hostname":
-    ensure  => present,
-    content => "${::hostname}\n",
-    owner   => "root",
-    group   => "root",
-    mode    => "0644",
-  }
   # Create user accounts
   create_resources( 'account', hiera_hash('accounts') )
 


### PR DESCRIPTION
This has now been set correctly across all environments. It is an odd,
self referential thing to have in place as facter loads this from the
system.
