### PR TITLE
Install screenshot-as-a-service required packages

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -62,3 +62,9 @@ lumberjack_instances:
     log_files: [ '/var/log/nginx/*.access.log.json' ]
   varnish:
     log_files: [ '/var/log/varnish/varnishncsa.log' ]
+
+system_packages:
+  - libcairo2-dev
+  - libjpeg8-dev
+  - libpango1.0-dev
+  - libgif-dev


### PR DESCRIPTION
`build-essential` is already provided. Apart from that, should match what's installed when testing:

https://github.com/alphagov/screenshot-as-a-service/blob/master/.travis.yml
