### PR TITLE
Add assets vhost to the frontend machines

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -1,6 +1,7 @@
 ---
 classes:
   - 'nginx::server'
+  - 'performanceplatform::assets'
   - 'phantomjs'
   - 'screenshot_as_a_service::app'
   - 'spotlight::app'

--- a/manifests/nodes.pp
+++ b/manifests/nodes.pp
@@ -5,10 +5,14 @@ if empty($machine_role) {
     $machine_role   = regsubst($::hostname, '^(.*)-\d$', '\1')
 }
 
-# Nginx Vhosts for later use
+# Nginx vhosts for later use
 $domain_name         = hiera('domain_name')
 $public_domain_name  = hiera('public_domain_name', $domain_name)
+# Public vhosts
+$www_vhost           = join(['www',$public_domain_name],'.')
 $admin_vhost         = join(['admin',$public_domain_name],'.')
+$assets_vhost        = join(['assets',$public_domain_name],'.')
+# Private vhosts
 $deploy_vhost        = join(['deploy',$domain_name],'.')
 $elasticsearch_vhost = join(['elasticsearch', $domain_name], '.')
 $kibana_vhost        = join(['kibana', $domain_name], '.')
@@ -16,7 +20,6 @@ $graphite_vhost      = join(['graphite',$domain_name],'.')
 $logstash_vhost      = join(['logstash',$domain_name],'.')
 $logging_vhost       = join(['logging',$domain_name],'.')
 $alerts_vhost        = join(['alerts',$domain_name],'.')
-$www_vhost           = join(['www',$public_domain_name],'.')
 $spotlight_vhost     = join(['spotlight',$public_domain_name],'.')
 $screenshot_as_a_service_vhost = join(['screenshot', $public_domain_name], '.')
 

--- a/modules/performanceplatform/manifests/assets.pp
+++ b/modules/performanceplatform/manifests/assets.pp
@@ -1,0 +1,15 @@
+# == Class: performanceplatform::assets
+#
+# This class provides an nginx vhost that serves assets from
+# a dedicated assets subdomain. You should be able to set far
+# future cache headers on your assets here.
+class performanceplatform::assets (
+) {
+
+  nginx::vhost { 'assets-vhost':
+    servername => "${::assets_vhost}",
+    ssl        => true,
+    magic      => template('performanceplatform/assets-vhost.erb'),
+  }
+
+}

--- a/modules/performanceplatform/templates/assets-vhost.erb
+++ b/modules/performanceplatform/templates/assets-vhost.erb
@@ -1,0 +1,7 @@
+# Spotlight serves assets from the public directory
+# of the currently deployed version of the app.
+location /spotlight/ {
+  expires 2h;
+  rewrite ^/spotlight(.*)$ $1 break;
+  root /opt/spotlight/current/public;
+}


### PR DESCRIPTION
Like most things Puppet, I'm not sure if this is the cleanest way to achieve the desired result.

Assets will be served from `assets.env.pp-domain`.

This commit adds a vhost listening on 80 and 443 on that subdomain to the frontend machines, with a root inside `/var/www/{subdomain}` (by default).

It then adds some extra nginx config to the end of that server block so that all requests under `/spotlight` are served from the public directory of the current Spotlight deployment.

```
assets.perfplat.dev/spotlight/index.css -> /opt/spotlight/current/public/index.css
```

We set 2 hour cache times and send an etag. Once we've verified that we're doing proper cachebusting in the app, we can increase that `Expires` header to months or years.

I hope our admin interface will follow the same pattern.
