### PR TITLE
Update elasticsearch check

### DIFF
--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -79,4 +79,10 @@ class performanceplatform::elasticsearch(
     }'
   }
 
+  sensu::check { 'elasticsearch_is_out_of_memory':
+    command  => '/etc/sensu/community-plugins/plugins/files/check-tail.rb -f /var/log/elasticsearch/elasticsearch.log -l 50 -P OutOfMemory',
+    interval => 60,
+    handlers => 'pagerduty',
+  }
+
 }

--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -101,9 +101,7 @@ class performanceplatform::monitoring (
   }
 
   sensu::check { 'elasticsearch_is_out_of_memory':
-    command  => '/etc/sensu/community-plugins/plugins/files/check-tail.rb -f /var/log/elasticsearch/elasticsearch.log -l 50 -P OutOfMemory',
-    interval => 60,
-    handlers => 'pagerduty',
+    ensure => absent,
   }
 
   $graphite_fqdn = regsubst($::fqdn, '\.', '_', 'G')


### PR DESCRIPTION
Elasticsearch has moved from monitoring-1 to 2 new boxes. Our checks
need updating as a result.

We [should be able to remove the check on monitoring](https://github.com/alphagov/sensu-puppet/blob/master/lib/puppet/type/sensu_check.rb).
