### PR TITLE
Reduce cache time of Spotlight assets vhost

### DIFF
--- a/modules/performanceplatform/templates/assets-vhost.erb
+++ b/modules/performanceplatform/templates/assets-vhost.erb
@@ -1,7 +1,7 @@
 # Spotlight serves assets from the public directory
 # of the currently deployed version of the app.
 location /spotlight/ {
-  expires 2h;
+  expires 5m;
   rewrite ^/spotlight(.*)$ $1 break;
   root /opt/spotlight/current/public;
 }


### PR DESCRIPTION
Until we have proper cachebusting in place, we shouldn't cache this for
so long. Under the kind of load we'll see nginx won't have a problem
serving a few static files every couple of minutes.
