### PR TITLE
Really remove elasticsearch

### DIFF
--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -60,7 +60,19 @@ class performanceplatform::monitoring (
     ensure => absent,
   }
 
+  service { 'elasticsearch-elasticsearch':
+    ensure => stopped,
+  }
 
+  file { '/etc/init/elasticsearch-elasticsearch.conf':
+    ensure => absent,
+  }
+
+  file { '/var/lib/elasticsearch-elasticsearch':
+    ensure => absent,
+    recurse => true,
+    force => true,
+  }
 
   # Ensure monitoring is no longer responsible for running elasticsearch
   class { '::elasticsearch::install':


### PR DESCRIPTION
Removing the package doesn't stop service or cleanup files. Added
following resource removals.

Should be removed after we get rid of elasticsearch on monitoring boxes.
