### PR TITLE
Add agents to the two _status grep and drops

### DIFF
--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -102,13 +102,16 @@ class performanceplatform::monitoring (
     },
     negate => true,
     order  => 20,
+    instances => [ 'agent-1', 'agent-2' ],
   }
+
   logstash::filter::grep { 'ignore_gunicorn_status_request':
     match  => {
       '@message' => "\\\\\\\"GET /_status HTTP/1.0\\\\\\\"",
     },
     negate => true,
     order  => 20,
+    instances => [ 'agent-1', 'agent-2' ],
   }
 
   logstash::output::statsd { 'statsd':


### PR DESCRIPTION
We missed telling these check to run on both instances. Rectify this.
