### PR TITLE
Redirect Spotlight's assets to the assets vhost

### DIFF
--- a/modules/performanceplatform/manifests/app.pp
+++ b/modules/performanceplatform/manifests/app.pp
@@ -8,6 +8,7 @@ define performanceplatform::app (
   $config_path  = "/etc/gds/${title}",
   $servername   = $title,
   $proxy_ssl    = false,
+  $magic        = '',
   $extra_env    = {},
   $upstart_desc = "Upstart job for ${title}",
   $upstart_exec = "${app_path}/run-procfile.sh",
@@ -29,6 +30,7 @@ define performanceplatform::app (
     upstream_port => $port,
     servername    => $servername,
     ssl           => $proxy_ssl,
+    magic         => $magic,
   }
 
   $base_environment = {

--- a/modules/spotlight/manifests/app.pp
+++ b/modules/spotlight/manifests/app.pp
@@ -16,6 +16,7 @@ class spotlight::app (
     group        => $group,
     servername   => $::spotlight_vhost,
     proxy_ssl    => true,
+    magic        => template('spotlight/assets-redirect.erb'),
     extra_env    => {
       'NODE_ENV' => $::pp_environment,
     },

--- a/modules/spotlight/templates/assets-redirect.erb
+++ b/modules/spotlight/templates/assets-redirect.erb
@@ -1,0 +1,5 @@
+# Send all requests to Spotlight's assets directory to
+# the spotlight directory on the assets vhost.
+location /assets/ {
+  rewrite ^/assets/(.*)$ https://<%= @assets_vhost %>/spotlight/$1 permanent;
+}


### PR DESCRIPTION
Pass in magic from the `performanceplatform::app`, and make use of it in the `spotlight::app`.

Redirect:

```
http://spotlight.perfplat.dev/assets -> http://assets.perfplat.dev/spotlight
```
