### PR TITLE
Make the logstash process check more reasonable.

### DIFF
--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -131,7 +131,7 @@ class performanceplatform::monitoring (
   }
 
   sensu::check { 'logstash_is_down':
-    command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p logstash -C 1 -c 2',
+    command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p logstash -C 1 -c -1 -w -1 -W 2',
     interval => 60,
     handlers => 'pagerduty',
   }


### PR DESCRIPTION
It was firing to much so I have shifted it to not care if there are too
many process, warning if there is less than 2 and critical if less than
1
