### PR TITLE
Remove removal of non-existant service

### DIFF
--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -55,13 +55,6 @@ class performanceplatform::monitoring (
     notify               => Class['sensu'],
   }
 
-  service { 'logstash-agent':
-    ensure => stopped,
-  } ->
-  file { '/etc/init.d/logstash-agent':
-    ensure => absent,
-  }
-
   logstash::input::lumberjack { 'lumberjack-agent-1':
     format          => 'json',
     type            => 'lumberjack',


### PR DESCRIPTION
The service has now been removed through all environments so this code
is no longer needed.
