### PR TITLE
Ignore too many processes

### DIFF
--- a/modules/performanceplatform/manifests/mongo.pp
+++ b/modules/performanceplatform/manifests/mongo.pp
@@ -57,7 +57,7 @@ rs.initiate(replicaSetConfig());
     $escaped_fqdn = regsubst($::fqdn, '\.', '_', 'G')
 
     sensu::check { "mongod_is_down_${escaped_fqdn}":
-      command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p mongod -W 1 -C 1',
+      command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p mongod -W 1 -C 1 -w -1 -c -1',
       interval => 60,
       handlers => 'pagerduty',
     }


### PR DESCRIPTION
At the moment our alerts for mongo fire if there are more than one
process running. This causes regular firing when our sync scripts are
running. We are not bothered if there are too many process are running,
only too few so I have set the check to ignore too many processes.
