### PR TITLE
Purge old lumberjack config from all app machines

### DIFF
--- a/modules/performanceplatform/manifests/app.pp
+++ b/modules/performanceplatform/manifests/app.pp
@@ -57,4 +57,18 @@ define performanceplatform::app (
   lumberjack::logshipper { "var-logs-for-${title}":
     log_files => [ "/var/log/${title}/*.log.json"],
   }
+
+  # FIXME: Purge old lumberjack logshipper config
+  # Remove once deployed to production
+  # Doing this by hand as lumberjack::logshipper doesn't
+  # provide a way to purge
+  service { "${title}-logshipper":
+    ensure => stopped,
+  } ->
+  file { "/etc/init/${title}-logshipper.conf":
+    ensure => absent,
+  } ->
+  file { "/etc/lumberjack/${title}-logshipper.json":
+    ensure => absent,
+  }
 }

--- a/modules/performanceplatform/manifests/assets.pp
+++ b/modules/performanceplatform/manifests/assets.pp
@@ -7,7 +7,7 @@ class performanceplatform::assets (
 ) {
 
   nginx::vhost { 'assets-vhost':
-    servername => "${::assets_vhost}",
+    servername => $::assets_vhost,
     ssl        => true,
     magic      => template('performanceplatform/assets-vhost.erb'),
   }

--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -74,22 +74,22 @@ class performanceplatform::monitoring (
   }
 
   logstash::input::syslog { 'logstash-syslog':
-    type => "syslog",
-    tags => ["syslog"],
+    type      => "syslog",
+    tags      => ["syslog"],
     instances => [ 'agent-1', 'agent-2' ],
   }
 
   logstash::filter::date { 'varnish-timestamp-fix':
-    type  => 'lumberjack',
-    tags  => [ 'varnish' ],
-    match => [ 'timestamp', '[dd/MMM/YYYY:HH:mm:ss Z]' ],
+    type      => 'lumberjack',
+    tags      => [ 'varnish' ],
+    match     => [ 'timestamp', '[dd/MMM/YYYY:HH:mm:ss Z]' ],
     instances => [ 'agent-1', 'agent-2' ],
   }
 
   logstash::filter::mutate { 'nginx-token-fix':
-    type => 'lumberjack',
-    tags => [ 'nginx' ],
-    gsub => [
+    type      => 'lumberjack',
+    tags      => [ 'nginx' ],
+    gsub      => [
       '@source_host', '\.', '_',
       'server_name',  '\.', '_',
     ],
@@ -97,20 +97,20 @@ class performanceplatform::monitoring (
   }
 
   logstash::filter::grep { 'ignore_backdrop_status_request':
-    match  => {
+    match     => {
       '@message' => "\\\"(request|response): GET .*/_status( - 200 OK)?\\\"",
     },
-    negate => true,
-    order  => 20,
+    negate    => true,
+    order     => 20,
     instances => [ 'agent-1', 'agent-2' ],
   }
 
   logstash::filter::grep { 'ignore_gunicorn_status_request':
-    match  => {
+    match     => {
       '@message' => "\\\\\\\"GET /_status HTTP/1.0\\\\\\\"",
     },
-    negate => true,
-    order  => 20,
+    negate    => true,
+    order     => 20,
     instances => [ 'agent-1', 'agent-2' ],
   }
 
@@ -126,7 +126,7 @@ class performanceplatform::monitoring (
   }
 
   logstash::output::elasticsearch_http { 'elasticsearch':
-    host => 'elasticsearch',
+    host      => 'elasticsearch',
     instances => [ 'agent-1', 'agent-2' ],
   }
 


### PR DESCRIPTION
These services are still in place from an old Puppet deploy but should not be there anymore. Remove the three things that `lumberjack::logshipper` adds.
