### PR TITLE
Ensure CNAMEs are unique for dnsmasq

### DIFF
--- a/modules/performanceplatform/manifests/dns.pp
+++ b/modules/performanceplatform/manifests/dns.pp
@@ -10,6 +10,8 @@ class performanceplatform::dns (
   validate_array($aliases)
   validate_array($cnames)
 
+  $unique_cnames = unique($cnames)
+
   dnsmasq::conf { 'internal-dns':
       ensure  => present,
       content => template('performanceplatform/internal-dns.erb'),

--- a/modules/performanceplatform/templates/internal-dns.erb
+++ b/modules/performanceplatform/templates/internal-dns.erb
@@ -18,6 +18,6 @@ alias=<%= pair[0] %>,<%= pair[1] %>
 <%- end -%>
 
 # cname apps and other vhosts to node roles
-<%- @cnames.each do |pair| -%>
+<%- @unique_cnames.each do |pair| -%>
 cname=<%= pair[0] %>,<%= pair[1] %>
 <%- end -%>


### PR DESCRIPTION
dnsmasq will error if you have duplicate CNAMEs in your config:

```
$ sudo /etc/init.d/dnsmasq restart
 * Restarting DNS forwarder and DHCP server configuration syntax check       [fail]
```

Remove duplicate CNAMEs using `unique()`.
