### PR TITLE
Fix cronjob to delete old elasticsearch indices

### DIFF
--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -32,7 +32,7 @@ class performanceplatform::elasticsearch(
     user    => 'nobody',
     hour    => '0',
     minute  => '1',
-    command => '/usr/local/bin/es-rotate --delete-old --delete-maxage 21 --optimize-old --optimize-maxage 1 logs',
+    command => '/usr/local/bin/es-rotate --delete-old --delete-maxage 21 --optimize-old --optimize-maxage 1 logstash',
     require => Class['::elasticsearch'],
   }
 


### PR DESCRIPTION
The string at the end is the prefix, which on our machines is logstash.
