### PR TITLE
Don't dump Java heap in OOM

### DIFF
--- a/modules/performanceplatform/files/etc/sysconfig/logstash.prod.defaults
+++ b/modules/performanceplatform/files/etc/sysconfig/logstash.prod.defaults
@@ -5,7 +5,7 @@
 START=true
 
 # Java options
-LS_JAVA_OPTS="${LS_JAVA_OPTS} -XX:+HeapDumpOnOutOfMemoryError -Xms1024m -Xmx1024m"
+LS_JAVA_OPTS="${LS_JAVA_OPTS} -Xms1024m -Xmx1024m"
 
 # Open files limit
 #OPEN_FILES=2049


### PR DESCRIPTION
We never look at them, and they are quite big on our limited disk
partition.
