### PR TITLE
Improve proxy vhost sensu checks

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -59,6 +59,8 @@ vhost_proxies:
         upstream_port:   8080
         access_logs:
             '{name}.access.log.json': 'json_event'
+        four_warning:  ':3'
+        four_critical: ':5'
     graphite-vhost:
         servername:      "%{::graphite_vhost}"
         ssl:             true
@@ -68,6 +70,8 @@ vhost_proxies:
         forward_host_header: false
         access_logs:
             '{name}.access.log.json': 'json_event'
+        four_warning:  ':3'
+        four_critical: ':5'
     alerts-vhost:
         servername:      "%{::alerts_vhost}"
         ssl:             true
@@ -76,6 +80,8 @@ vhost_proxies:
         upstream_port:   80
         access_logs:
             '{name}.access.log.json': 'json_event'
+        four_warning:  ':3'
+        four_critical: ':5'
     elasticsearch-vhost:
         servername:      "%{::elasticsearch_vhost}"
         ssl:             true
@@ -85,6 +91,8 @@ vhost_proxies:
         proxy_magic:     'limit_except GET POST HEAD OPTIONS { deny all; }'
         access_logs:
             '{name}.access.log.json': 'json_event'
+        four_warning:  ':3'
+        four_critical: ':5'
 
 nginx_conf:
     logging:

--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -31,7 +31,8 @@ define performanceplatform::proxy_vhost(
 
   if $sensu_check {
     performanceplatform::graphite_check { "5xx_rate_${servername}":
-      target            => "keepLastValue(movingAverage(sumSeries(stats.nginx.${::hostname}.${graphite_servername}.http_5*),60))",
+      # Total number of 5xx requests over the last minute
+      target            => "hitcount(transformNull(stats.nginx.${::hostname}.${graphite_servername}.http_5*,0),'1min')",
       warning           => $five_warning,
       critical          => $five_critical,
       interval          => 60,
@@ -40,12 +41,20 @@ define performanceplatform::proxy_vhost(
     }
 
     performanceplatform::graphite_check { "4xx_rate_${servername}":
-      target            => "keepLastValue(movingAverage(sumSeries(stats.nginx.${::hostname}.${graphite_servername}.http_4*),60))",
+      # Total number of 4xx requests over the last minute
+      target            => "hitcount(transformNull(stats.nginx.${::hostname}.${graphite_servername}.http_4*,0),'1min')",
       warning           => $four_warning,
       critical          => $four_critical,
       interval          => 60,
       ignore_no_data    => true,
       ignore_http_error => true,
+    }
+  } else {
+    sensu::check { "5xx_rate_${servername}":
+      command => "",
+    }
+    sensu::check { "4xx_rate_${servername}":
+      command => "",
     }
   }
 


### PR DESCRIPTION
- Measure on the total number of matching requests over the previous 1
  minute. `keepLastValue` means that the line doesn't drop to zero until
  all non-zero records have fallen out of the window. It is also a bit
  harder to understand.
- Set graphite sensu checks to be empty if `$sensu_check` is switched
  off. Apparently this is the only way sensu checks can be disabled
  right now.
- Add more lenient 4xx limits for monitoring apps
