### PR TITLE
Improve CPU checks

### DIFF
--- a/modules/performanceplatform/manifests/server_checks.pp
+++ b/modules/performanceplatform/manifests/server_checks.pp
@@ -5,10 +5,16 @@ define performanceplatform::server_checks(
     $graphite_fqdn = regsubst($fqdn, '\.', '_', 'G')
 
     performanceplatform::graphite_check { "check_high_cpu_${name}":
-      target   => "collectd.${graphite_fqdn}.cpu-0.cpu-idle",
+      target   => "movingAverage(collectd.${graphite_fqdn}.cpu-0.cpu-idle, 60)",
       warning  => '20:',
       critical => '5:',
       interval => 60,
+    }
+    performanceplatform::graphite_check { "check_high_cpu_spike_${name}":
+      target   => "movingAverage(collectd.${graphite_fqdn}.cpu-0.cpu-idle, 10)",
+      warning  => '10:',
+      critical => '1:',
+      interval => 10,
     }
 
     performanceplatform::graphite_check { "check_low_disk_space_${name}":


### PR DESCRIPTION
The previous check was being sampled every minute but only considered
the last sample. Here we replace the check with two checks, one that
runs a moving average over the previous 60 seconds every minute which
will tell us if a machine is under sustained load. We also have a
check averaged over the previous 10 seconds every 10 seconds which will
highlight short sharp spikes.
