### PR TITLE
Remove spaces from graphite check target

### DIFF
--- a/modules/performanceplatform/manifests/server_checks.pp
+++ b/modules/performanceplatform/manifests/server_checks.pp
@@ -5,13 +5,13 @@ define performanceplatform::server_checks(
     $graphite_fqdn = regsubst($fqdn, '\.', '_', 'G')
 
     performanceplatform::graphite_check { "check_high_cpu_${name}":
-      target   => "movingAverage(collectd.${graphite_fqdn}.cpu-0.cpu-idle, 60)",
+      target   => "movingAverage(collectd.${graphite_fqdn}.cpu-0.cpu-idle,60)",
       warning  => '20:',
       critical => '5:',
       interval => 60,
     }
     performanceplatform::graphite_check { "check_high_cpu_spike_${name}":
-      target   => "movingAverage(collectd.${graphite_fqdn}.cpu-0.cpu-idle, 10)",
+      target   => "movingAverage(collectd.${graphite_fqdn}.cpu-0.cpu-idle,10)",
       warning  => '10:',
       critical => '1:',
       interval => 10,


### PR DESCRIPTION
It causes check to fail with invalid URI.
