### PR TITLE
Add a reinstall_dependencies script, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ these commands from the host machine from inside this repo's directory:
     bundle install --without NONEXISTENT
     bundle exec librarian-puppet install
 
+Also see the ``tools/reinstall_dependencies`` script.
+
+Note that you may need a newer version of ruby than your system one: 1.9.3-p448
+is a good bet. You'll probably want to use
+[rbenv](https://github.com/sstephenson/rbenv) and
+[ruby-build](https://github.com/sstephenson/ruby-build) to manage multiple
+ruby versions, then install the ``bundler`` gem with 
+``$ gem install bundler && rbenv rehash``
+
 ## Tests!
 
 The intention is that this repo refers to external well-tested modules via the Puppetfile.

--- a/tools/reinstall_dependencies
+++ b/tools/reinstall_dependencies
@@ -1,0 +1,37 @@
+#!/bin/sh -ex
+
+THIS_SCRIPT=$(readlink -f $0)
+THIS_DIR=$(dirname ${THIS_SCRIPT})
+
+REPO_DIR=$(dirname ${THIS_DIR}/..)
+
+function delete_ruby_bundles {
+    rm -rf ${REPO_DIR}/vendor/bundle
+}
+
+function delete_puppet_modules {
+    rm -rf ${REPO_DIR}/vendor/modules
+}
+
+function delete_librarian_cache {
+    rm -rf ${REPO_DIR}/.tmp/librarian
+}
+
+function install_ruby_bundles {
+    pushd ${REPO_DIR}
+    bundle install --without NONEXISTENT
+    popd
+}
+
+function install_puppet_modules {
+    pushd ${REPO_DIR}
+    bundle exec librarian-puppet install
+    popd
+}
+
+delete_ruby_bundles
+delete_puppet_modules
+delete_librarian_cache
+
+install_ruby_bundles
+install_puppet_modules


### PR DESCRIPTION
I got annoyed at running the reinstall dependencies commands, doubly so when
when I discovered that puppet manifests are cached to `.tmp/librarian`.

Also for the Ruby uninitiated it's more efficient for the README to
gently signpost towards rbenv and ruby-build than let them struggle with
their out-of-date system installed ruby :)
