### PR TITLE
Upgrade sensu to 0.12 and sensu puppet to 0.7.7

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -12,6 +12,7 @@ mod 'puppetlabs/vcsrepo',         '0.1.2'
 mod 'saz/dnsmasq',                '1.0.1'
 mod 'saz/ntp',                    '2.0.3'
 mod 'saz/rsyslog',                '2.0.0'
+mod 'sensu/sensu',                '0.7.7'
 mod 'smarchive/archive',          '0.1.1'
 mod 'thomasvandoren/redis',       '0.0.9'
 mod 'netmanagers/fail2ban',       '1.1.0'
@@ -45,8 +46,6 @@ mod 'nginx',         :git => 'git://github.com/alphagov/puppet-nginx.git',
                      :ref => 'e60b12ddfbf22862ad0fdcc12056b5c5f3089795'
 mod 'python',        :git => 'git://github.com/stankevich/puppet-python.git',
                      :ref => 'f508b71d534f3c67db12886fa914cb4ef74bbe7a'
-mod 'sensu',         :git => 'git://github.com/alphagov/sensu-puppet.git',
-                     :ref => 'fix-check-deps'
 mod 'ssl',           :git => 'git://github.com/alphagov/puppet-ssl.git',
                      :ref => '23bbb5ab57f26269acce3d4b43e643781747a551'
 mod 'upstart',       :git => 'git://github.com/bison/puppet-upstart.git',

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -42,6 +42,9 @@ FORGE
     saz/dnsmasq (1.0.1)
     saz/ntp (2.0.3)
     saz/rsyslog (2.0.0)
+    sensu/sensu (0.7.7)
+      puppetlabs/apt (>= 0.0.1)
+      puppetlabs/stdlib (>= 0.0.1)
     smarchive/archive (0.1.1)
     stahnma/epel (0.0.5)
     thomasvandoren/redis (0.0.9)
@@ -138,15 +141,6 @@ GIT
       puppetlabs/apt (>= 0.0.2)
 
 GIT
-  remote: git://github.com/alphagov/sensu-puppet.git
-  ref: fix-check-deps
-  sha: 66d80a3c84c08074a26ce6ae967f109eeb97b77f
-  specs:
-    sensu (0.7.5)
-      puppetlabs/apt (>= 0.0.1)
-      puppetlabs/stdlib (>= 0.0.1)
-
-GIT
   remote: git://github.com/bison/puppet-upstart.git
   ref: 05a10a3a58de3543eb51bb782a249cebf71f5cd8
   sha: 05a10a3a58de3543eb51bb782a249cebf71f5cd8
@@ -228,7 +222,7 @@ DEPENDENCIES
   saz/dnsmasq (= 1.0.1)
   saz/ntp (= 2.0.3)
   saz/rsyslog (= 2.0.0)
-  sensu (>= 0)
+  sensu/sensu (= 0.7.7)
   smarchive/archive (= 0.1.1)
   ssl (>= 0)
   thomasvandoren/redis (= 0.0.9)

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -128,7 +128,7 @@ sensu::rabbitmq_host: 'rabbitmq'
 sensu::rabbitmq_password: "%{::rabbitmq_sensu_password}"
 sensu::rabbitmq_port: 5672
 sensu::safe_mode: true
-sensu::version: '0.11.0-1'
+sensu::version: '0.12.1-1'
 
 lumberjack::hosts:
   - 'logstash:3456'


### PR DESCRIPTION
- Old versions: sensu 0.11, sensu puppet 0.7.5 (patched)
- With sensu puppet 0.7.5 we used to maintain a github repo because the
  ordering of puppet installations meant that sometimes files in
  /etc/sensu/conf.d/checks/*.json were not generated.
- Upgrade to 0.7.7 direct from puppetforge as above bug no longer appears
  to be the case.

I (@paulfurley) have confimed with @robyoung that for a freshly provisioned monitoring-1 box, the checks are installed into `/etc/conf.d/checks/` before the services are started.

Note that we did, however, discover [this bug](https://www.pivotaltracker.com/story/show/62625052) - the gist of which is that later provisioning brand new checks does not cause sensu to be restarted.
