### PR TITLE
Use bash (not sh), fix REPO_DIR to be relative and use mv over rm

### DIFF
--- a/tools/reinstall_dependencies
+++ b/tools/reinstall_dependencies
@@ -1,37 +1,53 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
-THIS_SCRIPT=$(readlink -f $0)
+THIS_SCRIPT=$0
 THIS_DIR=$(dirname ${THIS_SCRIPT})
 
-REPO_DIR=$(dirname ${THIS_DIR})
+REPO_DIR=${THIS_DIR}/..
 
 function delete_ruby_bundles {
-    rm -rf ${REPO_DIR}/vendor/bundle
+    DIR=${REPO_DIR}/vendor/bundle
+    _soft_delete_directory ${DIR}
 }
 
 function delete_puppet_modules {
-    rm -rf ${REPO_DIR}/vendor/modules
+    DIR=${REPO_DIR}/vendor/modules
+    _soft_delete_directory ${DIR}
 }
 
 function delete_librarian_cache {
-    rm -rf ${REPO_DIR}/.tmp/librarian
+    DIR=${REPO_DIR}/.tmp/librarian
+    _soft_delete_directory ${DIR}
 }
 
 function install_ruby_bundles {
+    echo "Fresh installing ruby bundles."
     pushd ${REPO_DIR}
     bundle install --without NONEXISTENT
     popd
 }
 
 function install_puppet_modules {
+    echo "Fresh installing puppet modules."
     pushd ${REPO_DIR}
     bundle exec librarian-puppet install
     popd
 }
 
+function _soft_delete_directory {
+    DIR=$1
+    if [ -d "$DIR" ]; then
+        rm -rf ${DIR}.BAK
+        mv -f ${DIR} ${DIR}.BAK
+        echo "Moved ${DIR} to ${DIR}.BAK"
+    fi
+}
+
+
 delete_ruby_bundles
 delete_puppet_modules
 delete_librarian_cache
 
+sleep 4s
 install_ruby_bundles
 install_puppet_modules

--- a/tools/reinstall_dependencies
+++ b/tools/reinstall_dependencies
@@ -1,9 +1,9 @@
-#!/bin/sh -ex
+#!/bin/bash -ex
 
 THIS_SCRIPT=$(readlink -f $0)
 THIS_DIR=$(dirname ${THIS_SCRIPT})
 
-REPO_DIR=$(dirname ${THIS_DIR}/..)
+REPO_DIR=$(dirname ${THIS_DIR})
 
 function delete_ruby_bundles {
     rm -rf ${REPO_DIR}/vendor/bundle


### PR DESCRIPTION
- Turns out function doesn't work in /bin/sh, so changed to /bin/bash
- Mac OS X doesn't implement `readlink -f` and getting absolute path
  of running script in a portal way appears to be horrible.
- Latest mishap with `rm -rf` has led me to believe that `mv`ing the
  directory is somewhat safer than `rm`.
- Output human-friendly status, don't echo every command.
