### PR TITLE
Add node.js dependencies to the jumpbox

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -2,6 +2,7 @@ classes:
     - 'performanceplatform::jenkins'
     - 'performanceplatform::deploy'
     - 'performanceplatform::kibana'
+    - 'performanceplatform::nodejs'
     - 'python'
     - 'nginx::server'
     - 'google_credentials'

--- a/modules/performanceplatform/manifests/postgresql_primary.pp
+++ b/modules/performanceplatform/manifests/postgresql_primary.pp
@@ -3,7 +3,7 @@ class performanceplatform::postgresql_primary {
     # Don't install from the postgresql PPA. See "postgresql::globals" @
     # See https://forge.puppetlabs.com/puppetlabs/postgresql#setup
     manage_package_repo => false,
-    version => '9.1',
+    version             => '9.1',
   }->
   class { 'postgresql::server':
   }


### PR DESCRIPTION
So that we can do the build there before deploying.
