### PR TITLE
Provide redis list key to logstash input

### DIFF
--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -74,6 +74,7 @@ class performanceplatform::monitoring (
     type      => 'sensu',
     tags      => ['sensu'],
     data_type => 'list',
+    key       => 'sensu-checks',
     host      => 'redis',
     instances => [ 'agent-1', 'agent-2' ],
   }


### PR DESCRIPTION
Duh! If we want logstash to pull stuff from Redis we probably need to
tell it which key to look at.
