### PR TITLE
Add redis gem to monitoring machine

### DIFF
--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -14,7 +14,7 @@ class performanceplatform::monitoring (
     subscribe => Service['nginx'],
   }
 
-  package { 'redphone':
+  package { ['redphone', 'redis']:
     ensure   => installed,
     provider => 'gem',
     require  => Package['ruby1.9.1-dev'],


### PR DESCRIPTION
It is needed for the logstash sensu check as it adds it to a redis list.
