### PR TITLE
Use separated backdrop admin app

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -12,7 +12,7 @@ backdrop_apps:
   admin.backdrop:
     port:       3203
     # This is a placeholder until we extract a separate app
-    app_module: 'backdrop.write.api:app'
+    app_module: 'backdrop.admin.app:app'
     user:       'deploy'
     group:      'deploy'
   read.backdrop:

--- a/modules/varnish/templates/default.vcl.development.erb
+++ b/modules/varnish/templates/default.vcl.development.erb
@@ -24,14 +24,8 @@ sub vcl_recv {
   # Routing
   # Allow all HTTP Methods for admin
   if (req.http.Host ~ "^admin\..*") {
-    if (req.url ~ "^\/?$") {
-      # redirect / to /_user for the admin application
-      set req.http.x-Redir-Url = regsub(req.url, "^(.+)$", "/_user");
-      error 667 req.http.x-Redir-Url;
-    } else {
-      set req.http.Host = "admin.backdrop";
-      set req.backend   = admin_backend;
-    }
+    set req.http.Host = "admin.backdrop";
+    set req.backend   = admin_backend;
   # Send POST requests to the write api
   } else if (req.request == "POST") {
     if (req.http.Authorization ~ "^Bearer .*") {

--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -85,14 +85,8 @@ sub vcl_recv {
   # Routing
   # Allow all HTTP Methods for admin
   if (req.http.Host ~ "^admin\..*") {
-    if (req.url ~ "^\/?$") {
-      # redirect / to /_user for the admin application
-      set req.http.x-Redir-Url = regsub(req.url, "^(.+)$", "/_user");
-      error 667 req.http.x-Redir-Url;
-    } else {
-      set req.http.Host = "admin.backdrop";
-      set req.backend   = admin_director;
-    }
+    set req.http.Host = "admin.backdrop";
+    set req.backend   = admin_director;
   # Send POST requests to the write api
   } else if (req.request == "POST") {
     if (req.http.Authorization ~ "^Bearer .*") {


### PR DESCRIPTION
Switch over to using the separated admin app introduced with https://github.com/alphagov/backdrop/pull/209.

It also removed the redirect to `/_user` from the varnish configuration. This redirect is not needed with the new app as it is served off `/`.

This should not be deployed to any environment before the backdrop changes. 
