### PR TITLE
Remove es-rotate optimization util available

### DIFF
--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -32,7 +32,7 @@ class performanceplatform::elasticsearch(
     user    => 'nobody',
     hour    => '0',
     minute  => '1',
-    command => '/usr/local/bin/es-rotate --delete-old --delete-maxage 21 --optimize-old --optimize-maxage 1 logstash',
+    command => '/usr/local/bin/es-rotate --delete-old --delete-maxage 21 logstash',
     require => Class['::elasticsearch'],
   }
 


### PR DESCRIPTION
It can be added back in when
https://github.com/gds-operations/puppet-elasticsearch/pull/9 is merged.

We are currently not removing old logs and fast running out of disk space.
