### PR TITLE
Remove the -s argument from cluster status check

### DIFF
--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -93,7 +93,7 @@ class performanceplatform::elasticsearch(
   }
 
   sensu::check { 'elasticsearch_cluster_status':
-    command  => "/etc/sensu/community-plugins/plugins/elasticsearch/check-es-cluster-status.rb -s ${::hostname}",
+    command  => "/etc/sensu/community-plugins/plugins/elasticsearch/check-es-cluster-status.rb",
     interval => 60,
     handlers => ['default'],
     require  => Package['rest-client'],


### PR DESCRIPTION
The version of sensu-community-plugins we are using doesn't support the
-s argument. Our version will use http://localhost:9200 as its endpoint
which is fine for our setup.
