### PR TITLE
Adding Lumberjack resource

### DIFF
--- a/modules/backdrop_collector/manifests/app.pp
+++ b/modules/backdrop_collector/manifests/app.pp
@@ -19,4 +19,8 @@ define backdrop_collector::app ($user, $group) {
         group      => $group,
         require    => File["${app_path}/shared"],
     }
+
+    lumberjack::logshipper { "collector-logs-for-${title}":
+        log_files => [ "${app_path}/current/log/collector.log.json" ],
+    }
 }


### PR DESCRIPTION
So that they can be viewed in Kibana the collectors now output log files in JSON. Lumberjack needs to be configured so that Logstash can process them.
