### PR TITLE
Add logrotate config for backdrop gunicorn logs

### DIFF
--- a/modules/backdrop/manifests/app.pp
+++ b/modules/backdrop/manifests/app.pp
@@ -43,6 +43,12 @@ define backdrop::app (
         group   => $group,
         content => template('backdrop/gunicorn.logging.conf.erb')
     }
+    file { "/etc/logrotate.d/${title}-gunicorn":
+      ensure  => present,
+      owner   => $user,
+      group   => $group,
+      content => template('backdrop/gunicorn.logrotate.erb'),
+    }
     file { "${app_path}/run-procfile.sh":
         ensure  => present,
         owner   => $user,

--- a/modules/backdrop/templates/gunicorn.logrotate.erb
+++ b/modules/backdrop/templates/gunicorn.logrotate.erb
@@ -1,0 +1,11 @@
+/var/log/<%= title %>/*.log* {
+  rotate 12
+  weekly
+  missingok
+  compress
+  create 0640 <%= user %> <%= group %>
+  sharedscript
+  postrotate
+    kill -USR1 $(initctl status <%= title %> | awk '{ print $4 }')
+  endscript
+}


### PR DESCRIPTION
- Gunicorn logs are growing indefinitely
- The postrotate is nasty but upstart doesn't give you a way of sending
  a custom signal
