### PR TITLE
Fix asset compression

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -53,7 +53,8 @@ vhost_proxies:
     five_critical: 1
     magic: |
       gzip on;
-
+      gzip_types application/x-javascript application/javascript application/json text/css;
+      gzip_proxied no_etag;
 
 nginx::server::server_names_hash_bucket_size: 128
 

--- a/modules/performanceplatform/templates/assets-vhost.erb
+++ b/modules/performanceplatform/templates/assets-vhost.erb
@@ -5,4 +5,6 @@ location /spotlight/ {
   rewrite ^/spotlight(.*)$ $1 break;
   root /opt/spotlight/current/public;
   gzip on;
+  gzip_types application/x-javascript application/javascript application/json text/css;
+  gzip_proxied no_etag;
 }


### PR DESCRIPTION
Need to give explicit gzip_types to get things compressed.

Making the change in 2 places is a smell. Will raise a separate ticket
to investigate.

Setting no_etag for proxying content since backdrop responses should be
compressed across the internet, but ETags should change if the content
is compressed. Possibly needs reviewing.
