### PR TITLE
Provide proper instructions to proxy caches

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -55,6 +55,7 @@ vhost_proxies:
       gzip on;
       gzip_types application/x-javascript application/javascript application/json text/css;
       gzip_proxied no_etag;
+      gzip_vary on;
 
 nginx::server::server_names_hash_bucket_size: 128
 

--- a/modules/performanceplatform/templates/assets-vhost.erb
+++ b/modules/performanceplatform/templates/assets-vhost.erb
@@ -7,4 +7,5 @@ location /spotlight/ {
   gzip on;
   gzip_types application/x-javascript application/javascript application/json text/css;
   gzip_proxied no_etag;
+  gzip_vary on;
 }


### PR DESCRIPTION
Now that we're compressing content, we should also do this.

[Minor concern that IE6 won't do the right thing](http://wiki.nginx.org/HttpGzipModule#gzip_vary).
