### PR TITLE
Install bowler on dev VM

### DIFF
--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -3,6 +3,7 @@ classes:
   - 'clamav'
   - 'google_credentials'
   - 'nginx::server'
+  - 'performanceplatform::dev'
   - 'performanceplatform::nodejs'
   - 'performanceplatform::mongo'
   - 'phantomjs'

--- a/modules/performanceplatform/manifests/dev.pp
+++ b/modules/performanceplatform/manifests/dev.pp
@@ -1,0 +1,8 @@
+class performanceplatform::dev (
+) {
+    package {['bowler']:
+      ensure   => installed,
+      provider => gem,
+      require  => Package['ruby1.9.1-dev'],
+    }
+}


### PR DESCRIPTION
We recommend using bowler to run the apps, so install it already.

Replaces alphagov/pp-development#16
