### PR TITLE
Switch to ruby and python packages in hiera

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -215,3 +215,6 @@ system_packages:
   - ssl-cert
   - vim
   - libcurl4-gnutls-dev
+
+ruby_packages:
+  - sensu-plugin

--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -51,3 +51,6 @@ ufw_rules:
     port: 80
     ip:   'any'
 
+ruby_packages:
+  - curb
+  - json

--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -3,7 +3,6 @@ classes:
   - 'clamav'
   - 'google_credentials'
   - 'nginx::server'
-  - 'performanceplatform::dev'
   - 'performanceplatform::nodejs'
   - 'performanceplatform::mongo'
   - 'phantomjs'
@@ -76,3 +75,6 @@ system_packages:
   - libjpeg8-dev
   - libpango1.0-dev
   - libgif-dev
+
+ruby_packages:
+  - bowler

--- a/hieradata/role-logs-elasticsearch.yaml
+++ b/hieradata/role-logs-elasticsearch.yaml
@@ -19,3 +19,6 @@ ufw_rules:
   allowelasticsearchcontrolfromany:
     port: 9300
     ip:   'any'
+
+ruby_packages:
+  - rest-client

--- a/hieradata/role-monitoring.yaml
+++ b/hieradata/role-monitoring.yaml
@@ -91,3 +91,7 @@ nginx_conf:
 lumberjack_instances:
   nginx:
     log_files: [ '/var/log/nginx/*.access.log.json' ]
+
+ruby_packages:
+  - redphone
+  - redis

--- a/manifests/nodes.pp
+++ b/manifests/nodes.pp
@@ -45,6 +45,27 @@ node default {
     package { $system_packages: ensure => installed }
   }
 
+  $python_packages = hiera_array( 'python_packages', [] )
+  if !empty($python_packages) {
+    package { $python_packages:
+      ensure   => installed,
+      provider => 'pip',
+    }
+  }
+
+  $ruby_packages = hiera_array( 'ruby_packages', [] )
+  if !empty($ruby_packages) {
+    package { 'ruby1.9.1-dev':
+      ensure => installed,
+    }
+
+    package { $ruby_packages:
+      ensure   => installed,
+      provider => 'gem',
+      require  => 'ruby1.9.1-dev',
+    }
+  }
+
   # Firewall rules
   create_resources( 'ufw::allow', hiera_hash('ufw_rules') )
 

--- a/modules/performanceplatform/manifests/backdrop_smoke_tests.pp
+++ b/modules/performanceplatform/manifests/backdrop_smoke_tests.pp
@@ -3,12 +3,6 @@ class performanceplatform::backdrop_smoke_tests (
 ) {
     $check_data_path ="/etc/sensu/backdrop-write-read-test.rb"
 
-    package {['curb','json']:
-      ensure   => installed,
-      provider => gem,
-      require  => Package['ruby1.9.1-dev'],
-    }
-
     file { "/etc/sensu/backdrop-write-read-test.rb":
       require => Class['sensu'],
       owner   => 'root',

--- a/modules/performanceplatform/manifests/base.pp
+++ b/modules/performanceplatform/manifests/base.pp
@@ -49,16 +49,7 @@ FACTER_machine_role=${machine_role}
         group  => 'gds',
     }
 
-    package { 'ruby1.9.1-dev':
-        ensure => present,
-    }
-
-    package {'sensu-plugin':
-      ensure   => installed,
-      before   => Class['sensu'],
-      provider => gem,
-      require  => Package['ruby1.9.1-dev'],
-    }
+    Package['sensu-plugin'] -> Class['sensu']
 
     vcsrepo { '/etc/sensu/community-plugins':
         ensure   => present,

--- a/modules/performanceplatform/manifests/dev.pp
+++ b/modules/performanceplatform/manifests/dev.pp
@@ -1,8 +1,0 @@
-class performanceplatform::dev (
-) {
-    package {['bowler']:
-      ensure   => installed,
-      provider => gem,
-      require  => Package['ruby1.9.1-dev'],
-    }
-}

--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -80,12 +80,6 @@ class performanceplatform::elasticsearch(
   }
 
 
-  package { 'rest-client':
-    ensure   => installed,
-    provider => 'gem',
-    require  => Package['ruby1.9.1-dev'],
-  }
-
   sensu::check { 'elasticsearch_is_out_of_memory':
     command  => '/etc/sensu/community-plugins/plugins/files/check-tail.rb -f /var/log/elasticsearch/elasticsearch.log -l 50 -P OutOfMemory',
     interval => 60,

--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -14,12 +14,6 @@ class performanceplatform::monitoring (
     subscribe => Service['nginx'],
   }
 
-  package { ['redphone', 'redis']:
-    ensure   => installed,
-    provider => 'gem',
-    require  => Package['ruby1.9.1-dev'],
-  }
-
   Class['redis'] -> Class['sensu']
   Class['rabbitmq'] -> Class['sensu']
   Package['redphone'] -> Class['sensu']


### PR DESCRIPTION
Ruby and python packages should follow the same pattern as system
packages in terms of defining them for roles. Switching to this pattern
also allows more easy visibility of packages requested for install.
