### PR TITLE
Increase cache duration for Spotlight assets

### DIFF
--- a/modules/performanceplatform/templates/assets-vhost.erb
+++ b/modules/performanceplatform/templates/assets-vhost.erb
@@ -1,7 +1,7 @@
 # Spotlight serves assets from the public directory
 # of the currently deployed version of the app.
 location /spotlight/ {
-  expires 5m;
+  expires 1d;
   rewrite ^/spotlight(.*)$ $1 break;
   root /opt/spotlight/current/public;
   gzip on;


### PR DESCRIPTION
I'd like to increase the `Expires` header as an indication that I'm more confident in our ability to cachebust than I was previously.

Currently the only assets that won't be cachebusted are images in stylesheets and the govuk_template - the govuk_template will be cachebusted as soon as https://github.com/alphagov/govuk_template/pull/50 is merged and we update to it.

We're still seeing some odd issues whereby the page is rendered with no CSS. I think this is because the browser caches the HTML for half an hour which then references CSS that no longer exists. I think we can solve this by increasing the `Expires` header further and putting the assets vhost behind Varnish. Perhaps we should also investigate keeping old assets on the server for a period of time.
