### PR TITLE
Add the update-notifier pacakge to all machines

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -217,6 +217,7 @@ system_packages:
   - ssl-cert
   - vim
   - libcurl4-gnutls-dev
+  - update-notifier
 
 ruby_packages:
   - sensu-plugin


### PR DESCRIPTION
After setting up the apt checks we were seeing a file not found error
from python. This was due to me forgetting to install the
update-notifier package which is required for the script to work
