### PR TITLE
We should add alerts for the rate of new logs

### DIFF
--- a/hieradata/role-logs-elasticsearch.yaml
+++ b/hieradata/role-logs-elasticsearch.yaml
@@ -2,6 +2,7 @@ classes:
   - 'java7'
   - 'python'
   - 'performanceplatform::elasticsearch'
+  - 'performanceplatform::checks::elasticsearch::logging'
 
 
 performanceplatform::elasticsearch::data_dir: '/mnt/data/elasticsearch'

--- a/modules/performanceplatform/manifests/checks/elasticsearch/index.pp
+++ b/modules/performanceplatform/manifests/checks/elasticsearch/index.pp
@@ -1,0 +1,26 @@
+define performanceplatform::checks::elasticsearch::index(
+  $type,
+) {
+
+  $graphite_key_suffix = "elasticsearch_${name}_${type}"
+  $graphite_key = "curl_json-${graphite_key_suffix}.gauge-count"
+  $graphite_fqdn = regsubst($::fqdn, '\.', '_', 'G')
+  $graphite = "collectd.${graphite_fqdn}.${graphite_key}"
+
+  collectd::plugin::curl_json { $graphite_key_suffix:
+    url      => "http://localhost:9200/${name}/${type}/_count",
+    instance => $graphite_key_suffix,
+    keys     => {
+      count => { type => 'gauge' },
+    },
+  }
+
+  performanceplatform::checks::graphite { "check_rate_${name}_${type}":
+    target   => "removeBelowValue(derivative(${graphite},0)",
+    warning  => '0:',
+    critical => '0:',
+    interval => 60,
+    handlers => ['default'],
+  }
+
+}

--- a/modules/performanceplatform/manifests/checks/elasticsearch/logging.pp
+++ b/modules/performanceplatform/manifests/checks/elasticsearch/logging.pp
@@ -1,0 +1,12 @@
+class performanceplatform::checks::elasticsearch::logging(
+) {
+
+  performanceplatform::checks::elasticsearch::index { 'logstash-current':
+    type => 'lumberjack',
+  }
+
+  performanceplatform::checks::elasticsearch::index { 'logstash-current':
+    type => 'syslog',
+  }
+
+}

--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -79,22 +79,6 @@ class performanceplatform::elasticsearch(
     }'
   }
 
-  collectd::plugin::curl_json { 'lumberjack_count':
-    url => 'http://localhost:9200/logstash-current/lumberjack/_count',
-    instance => 'elasticsearch',
-    keys => {
-      count => { type => 'gauge' },
-    },
-  }
-
-  collectd::plugin::curl_json { 'syslog_count':
-    url => 'http://localhost:9200/logstash-current/syslog/_count',
-    instance => 'elasticsearch',
-    keys => {
-      count => { type => 'gauge' },
-    },
-  }
-
   sensu::check { 'elasticsearch_is_out_of_memory':
     command  => '/etc/sensu/community-plugins/plugins/files/check-tail.rb -f /var/log/elasticsearch/elasticsearch.log -l 50 -P OutOfMemory',
     interval => 60,


### PR DESCRIPTION
In order to clarify whether the logging pipeline is working we want to
check the rate of new logs entering elasticsearch. This works as we
expect a constant flow of logs to be picked up and elasticsearch is the
end of the line for our pipeline. If the rate hits zero then something
has broken in the pipeline
