### PR TITLE
Duplicate resource names, switch for check name

### DIFF
--- a/modules/performanceplatform/manifests/checks/elasticsearch/index.pp
+++ b/modules/performanceplatform/manifests/checks/elasticsearch/index.pp
@@ -1,21 +1,22 @@
 define performanceplatform::checks::elasticsearch::index(
+  $index,
   $type,
 ) {
 
-  $graphite_key_suffix = "elasticsearch_${name}_${type}"
+  $graphite_key_suffix = "elasticsearch_${index}_${type}"
   $graphite_key = "curl_json-${graphite_key_suffix}.gauge-count"
   $graphite_fqdn = regsubst($::fqdn, '\.', '_', 'G')
   $graphite = "collectd.${graphite_fqdn}.${graphite_key}"
 
   collectd::plugin::curl_json { $graphite_key_suffix:
-    url      => "http://localhost:9200/${name}/${type}/_count",
+    url      => "http://localhost:9200/${index}/${type}/_count",
     instance => $graphite_key_suffix,
     keys     => {
       count => { type => 'gauge' },
     },
   }
 
-  performanceplatform::checks::graphite { "check_rate_${name}_${type}":
+  performanceplatform::checks::graphite { $name:
     target   => "removeBelowValue(derivative(${graphite},0)",
     warning  => '0:',
     critical => '0:',

--- a/modules/performanceplatform/manifests/checks/elasticsearch/logging.pp
+++ b/modules/performanceplatform/manifests/checks/elasticsearch/logging.pp
@@ -1,11 +1,13 @@
 class performanceplatform::checks::elasticsearch::logging(
 ) {
 
-  performanceplatform::checks::elasticsearch::index { 'logstash-current':
+  performanceplatform::checks::elasticsearch::index { 'check_lumberjack_logging_rate':
+    index => 'logstash-current',
     type => 'lumberjack',
   }
 
-  performanceplatform::checks::elasticsearch::index { 'logstash-current':
+  performanceplatform::checks::elasticsearch::index { 'check_syslog_logging_rate':
+    index => 'logstash-current',
     type => 'syslog',
   }
 


### PR DESCRIPTION
Stupidly I used a duplicate resource name, this fixes it
