### PR TITLE
Use absolute paths when defining script to run

### DIFF
--- a/modules/performanceplatform/manifests/checks/apt.pp
+++ b/modules/performanceplatform/manifests/checks/apt.pp
@@ -2,14 +2,14 @@ class performanceplatform::checks::apt (
 ) {
 
   sensu::check { 'apt_reboot_check':
-    command  => "check_reboot_required 3 1",
+    command  => "/usr/local/bin/check_reboot_required 3 1",
     interval => 6 * 60 * 60,  # every 6 hours
     handlers => ['default'],
     require  => Package['gds-nagios-plugins'],
   }
 
   sensu::check { 'apt_security_updates':
-    command  => "check_apt_security_updates 0 0",
+    command  => "/usr/local/bin/check_apt_security_updates 0 0",
     interval => 6 * 60 * 60,  # every 6 hours
     handlers => ['default'],
     require  => Package['gds-nagios-plugins'],


### PR DESCRIPTION
When a machine restarts the services will be restarted with an empty
$PATH, so it is necessary to provide the whole path to the script to
run.
