### PR TITLE
Remove the CPU spike checks

### DIFF
--- a/modules/performanceplatform/manifests/checks/server.pp
+++ b/modules/performanceplatform/manifests/checks/server.pp
@@ -12,6 +12,11 @@ define performanceplatform::checks::server (
       handlers => ['default'],
     }
 
+    # TODO: Remove once check is removed from all machines
+    file { "/etc/sensu/conf.d/checks/check_high_cpu_spike_${name}":
+      ensure   => absent,
+    }
+
     performanceplatform::checks::graphite { "check_low_disk_space_${name}":
       target   => "collectd.${graphite_fqdn}.df-root.df_complex-free",
       warning  => '4000000000:', # A little less than 4 gig

--- a/modules/performanceplatform/manifests/checks/server.pp
+++ b/modules/performanceplatform/manifests/checks/server.pp
@@ -11,13 +11,6 @@ define performanceplatform::checks::server (
       interval => 60,
       handlers => ['default'],
     }
-    performanceplatform::checks::graphite { "check_high_cpu_spike_${name}":
-      target   => "movingAverage(collectd.${graphite_fqdn}.cpu-0.cpu-idle,10)",
-      warning  => '10:',
-      critical => '1:',
-      interval => 10,
-      handlers => ['default'],
-    }
 
     performanceplatform::checks::graphite { "check_low_disk_space_${name}":
       target   => "collectd.${graphite_fqdn}.df-root.df_complex-free",


### PR DESCRIPTION
Mongo frequently spikes, which causes these critical alerts.

These alerts are not indicative of a degradation in service as far as I can tell.

Please discuss.
