### PR TITLE
Add a postgres database for stagecraft

### DIFF
--- a/hieradata/environment.yaml
+++ b/hieradata/environment.yaml
@@ -22,6 +22,5 @@ performanceplatform::hosts::ip:
   - "%{::ipaddress_eth1}"
 
 postgresql::server::postgres_password: 'password'
-postgresql::server::listen_addresses: '*'
 
 performanceplatform::postgresql_primary::stagecraft_password: "securem8"

--- a/hieradata/environment.yaml
+++ b/hieradata/environment.yaml
@@ -15,9 +15,11 @@ fail2ban::whitelist_ips:
 
 rabbitmq_sensu_password: 'iP2O51333kzask7'
 
+
 # Keep elasticsearch heapsize low in dev
 performanceplatform::elasticsearch::heap_size: '256m'
-performanceplatform::hosts::ip: "%{::ipaddress_eth1}"
+performanceplatform::hosts::ip:
+  - "%{::ipaddress_eth1}"
 
-postgresql::server::postgres_password: 'super secret password'
-postgresql::server::listen_address: '0.0.0.0'
+postgresql::server::postgres_password: 'password'
+postgresql::server::listen_addresses: '*'

--- a/hieradata/environment.yaml
+++ b/hieradata/environment.yaml
@@ -23,3 +23,5 @@ performanceplatform::hosts::ip:
 
 postgresql::server::postgres_password: 'password'
 postgresql::server::listen_addresses: '*'
+
+performanceplatform::postgresql_primary::stagecraft_password: "securem8"

--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -7,6 +7,7 @@ classes:
   - 'performanceplatform::checks::backdrop'
   - 'performanceplatform::backdrop_smoke_tests'
   - 'python'
+  - 'postgresql::lib::devel'
 
 backdrop_apps:
   admin.backdrop:

--- a/hieradata/role-postgresql-primary.yaml
+++ b/hieradata/role-postgresql-primary.yaml
@@ -2,6 +2,8 @@
 classes:
   - 'performanceplatform::postgresql_primary'
 
+postgresql::server::listen_addresses: '*'
+
 ufw_rules:
   allowpostgresql:
     port: 5432

--- a/modules/performanceplatform/manifests/postgresql_primary.pp
+++ b/modules/performanceplatform/manifests/postgresql_primary.pp
@@ -15,4 +15,13 @@ class performanceplatform::postgresql_primary (
     user     => 'stagecraft',
     password => postgresql_password('stagecraft', $stagecraft_password),
   }
+
+  # Allow access to stagecraft from performance platform cluster
+  postgresql::server::pg_hba_rule { 'stagecraft':
+    type        => 'host',
+    database    => 'stagecraft',
+    user        => 'stagecraft',
+    auth_method => 'md5',
+    address     => '172.27.1.1/24',
+  }
 }

--- a/modules/performanceplatform/manifests/postgresql_primary.pp
+++ b/modules/performanceplatform/manifests/postgresql_primary.pp
@@ -1,4 +1,6 @@
-class performanceplatform::postgresql_primary {
+class performanceplatform::postgresql_primary (
+  $stagecraft_password
+) {
   class { 'postgresql::globals':
     # Don't install from the postgresql PPA. See "postgresql::globals" @
     # See https://forge.puppetlabs.com/puppetlabs/postgresql#setup
@@ -10,7 +12,7 @@ class performanceplatform::postgresql_primary {
 
   # Create stagecraft db
   postgresql::server::db { 'stagecraft':
-    user     => 'stagecraft_user',
-    password => postgresql_password('stagecraft_user', 'stagecraft_password'),
+    user     => 'stagecraft',
+    password => postgresql_password('stagecraft', $stagecraft_password),
   }
 }

--- a/modules/performanceplatform/manifests/postgresql_primary.pp
+++ b/modules/performanceplatform/manifests/postgresql_primary.pp
@@ -7,4 +7,10 @@ class performanceplatform::postgresql_primary {
   }->
   class { 'postgresql::server':
   }
+
+  # Create stagecraft db
+  postgresql::server::db { 'stagecraft':
+    user     => 'stagecraft_user',
+    password => postgresql_password('stagecraft_user', 'stagecraft_password'),
+  }
 }


### PR DESCRIPTION
- Create a database called stagecraft
- Create a user called stagecraft and give it access to the stagecraft database
- Allow access to the stagecraft database from all machines in the performance platform cluster
- Add postgres client library and headers to backend app servers so that python client can be created
