### PR TITLE
Add in additional manifest to setup postgres backups

### DIFF
--- a/hieradata/role-postgresql-primary.yaml
+++ b/hieradata/role-postgresql-primary.yaml
@@ -1,6 +1,7 @@
 ---
 classes:
   - 'performanceplatform::postgresql_primary'
+  - 'performanceplatform::postgresql_backup'
 
 postgresql::server::listen_addresses: '*'
 

--- a/modules/performanceplatform/manifests/postgresql_backup.pp
+++ b/modules/performanceplatform/manifests/postgresql_backup.pp
@@ -1,0 +1,59 @@
+# Class: postgresql::backup
+#
+# This class provides a way to set up backup for a postgresql cluster.
+# It will add a shell script based on the utility pg_dump to make
+# consitent backups each night.
+#
+# You must have declared the `postgresql` class before you use
+# this class.
+#
+# Parameters:
+#   ['backup_dir']    - The directory to use for backups.
+#                       Defaults to /var/backups/pgsql.
+#   ['backup_format'] - The backup format to use.
+#                       Defaults to plain.
+#   ['user']          - The user to use to perform the backup.
+#                       Defaults to postgres.
+#
+# Actions:
+# - Creates and manages a postgresql cluster
+#
+# Requires:
+# - `puppetlabs/stdlib`
+#
+# Sample Usage:
+#   include postgresql::backup
+#
+class performanceplatform::postgresql_backup (
+  $backup_dir = '/var/backups/pgsql',
+  $backup_format = 'plain',
+  $user = 'postgres',
+) {
+
+  file {$backup_dir:
+    ensure  => directory,
+    owner   => $user,
+    group   => $user,
+    mode    => '0755',
+    #require => [Package['puppetlabs/postgresql'], User[$user]],
+  }
+
+  file { '/usr/local/bin/pgsql-backup.sh':
+    ensure  => present,
+    owner   => root,
+    group   => root,
+    mode    => '0755',
+    content => template('performanceplatform/pgsql-backup.sh.erb'),
+    require => File[$backup_dir],
+  }
+
+  cron { 'pgsql-backup':
+    command => "/usr/local/bin/pgsql-backup.sh",
+    user    => $user,
+    hour    => 2,
+    minute  => 0,
+    # require => [User[$user], File['/usr/local/bin/pgsql-backup.sh']],
+    require => File['/usr/local/bin/pgsql-backup.sh'],
+  }
+
+}

--- a/modules/performanceplatform/manifests/postgresql_primary.pp
+++ b/modules/performanceplatform/manifests/postgresql_primary.pp
@@ -24,4 +24,5 @@ class performanceplatform::postgresql_primary (
     auth_method => 'md5',
     address     => '172.27.1.1/24',
   }
+
 }

--- a/modules/performanceplatform/templates/pgsql-backup.sh.erb
+++ b/modules/performanceplatform/templates/pgsql-backup.sh.erb
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+BKPDIR="<%= @backup_dir %>"
+BKPFMT="<%= @backup_format %>"
+TODAY=$(date +%F)
+DAY=$(date +%A |tr 'A-Z' 'a-z')
+MONTH=$(date +%B |tr 'A-Z' 'a-z')
+TMPDIR=$(mktemp -d -p $BKPDIR) || exit 1
+export PGOPTIONS='-c statement_timeout=0'
+
+pg_dumpall -U postgres --globals-only |bzip2 > $TMPDIR/ACCOUNT-OBJECTS.$TODAY.dump.bz
+
+for i in `psql -U postgres -c "select datname from pg_database where datname <> 'template0'" -t template1`
+    do
+        pg_dump -U postgres --format=$BKPFMT --create $i |bzip2  > $TMPDIR/$i.$TODAY.dump.bz
+    done
+
+test -f $BKPDIR/pgsql_$DAY.tar.gz && rm $BKPDIR/pgsql_$DAY.tar.gz
+tar -C $TMPDIR -c -f $BKPDIR/pgsql_$DAY.tar `ls $TMPDIR`
+rm -fr $TMPDIR
+
+if [ $(date +%d) = "01" ]; then
+    test -f $BKPDIR/pgsql_$MONTH.tar.gz && rm $BKPDIR/pgsql_$MONTH.tar.gz
+    cp $BKPDIR/pgsql_$DAY.tar $BKPDIR/pgsql_$MONTH.tar
+fi


### PR DESCRIPTION
![](http://24.media.tumblr.com/0e61d566c200332634ebc33b35b21c09/tumblr_n0cq1g8Ul31rjg379o1_500.jpg)
- Ensures that a directory _on the same box_ is created
- Sets a job to run every 2 hours using pg_dump
- Uses a template I found on the www's: https://github.com/ckaenzig/puppet-postgresql/blob/master/templates/pgsql-backup.sh.erb
- **NB:** This pull request is not the whole story - we should push to a separate box, as described here:
  https://www.pivotaltracker.com/s/projects/911872/stories/65578342
