### PR TITLE
Remove bucket health check

### DIFF
--- a/modules/performanceplatform/manifests/checks/backdrop.pp
+++ b/modules/performanceplatform/manifests/checks/backdrop.pp
@@ -18,8 +18,7 @@ class performanceplatform::checks::backdrop (
       handlers => ['default'],
     }
     sensu::check { "backdrop_buckets_health_check":
-      interval => 3600,
+      ensure   => absent,
       command  => "${check_data_path}  -u http://localhost:3038/_status/buckets",
-      handlers => ['default'],
     }
 }


### PR DESCRIPTION
Fixing these checks cannot be done by developers, which has left us with
a bunch of always firing checks. This is really not good so we should
remove them.
