### PR TITLE
Update librarian-puppet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'puppet', '3.1.1'
 group :build do
     gem 'facter', '1.7.1'
     gem 'hiera-puppet-helper'
-    gem 'librarian-puppet-maestrodev', '0.9.10.1'
+    gem 'librarian-puppet', '0.9.13'
     gem 'puppet-lint', '0.3.2'
     gem 'puppetlabs_spec_helper', '~>0.4'
     gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,18 +6,22 @@ GEM
     hiera (1.2.1)
       json_pure
     hiera-puppet-helper (1.0.1)
-    highline (1.6.19)
-    json (1.8.0)
+    highline (1.6.20)
+    json (1.8.1)
     json_pure (1.8.0)
-    librarian (0.1.1)
+    librarian (0.1.2)
       highline
       thor (~> 0.15)
-    librarian-puppet-maestrodev (0.9.10.1)
+    librarian-puppet (0.9.13)
       json
-      librarian (>= 0.1.1)
+      librarian (>= 0.1.2)
+      open3_backport
     metaclass (0.0.1)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
+    open3_backport (0.0.3)
+      open4 (~> 1.3.0)
+    open4 (1.3.2)
     puppet (3.1.1)
       facter (~> 1.6)
       hiera (~> 1.0)
@@ -46,7 +50,7 @@ PLATFORMS
 DEPENDENCIES
   facter (= 1.7.1)
   hiera-puppet-helper
-  librarian-puppet-maestrodev (= 0.9.10.1)
+  librarian-puppet (= 0.9.13)
   puppet (= 3.1.1)
   puppet-lint (= 0.3.2)
   puppetlabs_spec_helper (~> 0.4)


### PR DESCRIPTION
Use main codebase, and update to take advantage of
https://github.com/rodjek/librarian-puppet/pull/168 and hopefully
experience fewer corrupt cache instances.
