### PR TITLE
Add timestamps to openconnect upstart logs

### DIFF
--- a/modules/openconnect/templates/openconnect.conf.erb
+++ b/modules/openconnect/templates/openconnect.conf.erb
@@ -18,4 +18,4 @@ exec cat /etc/openconnect/network.passwd | openconnect \
   --CAfile /etc/openconnect/network.cacerts \
 <% end -%>
   --user <%= @user -%> \
-  --passwd-on-stdin
+  --passwd-on-stdin | awk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0; fflush(); }'


### PR DESCRIPTION
It is difficult to diagnose problems if we don't know when they
happened.

This is a little ghetto but there doesn't seem to be a better way of adding timestamps to a line stream that doesn't have them.
