### PR TITLE
Add libffi-dev to the jumpbox

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -36,9 +36,11 @@ python::version:    '2.7'
 python::dev:        true
 python::virtualenv: true
 
+# These packages are only required for building Transactions Explorer
 system_packages:
     - libxml2-dev
     - libxslt1-dev
+    - libffi-dev
 
 ufw_rules:
     allowhttpfromall:


### PR DESCRIPTION
I've just run `apt-get install libffi-dev` on `jumpbox-1.pp-preview`. It's now required by Transactions Explorer build :/

Are libxml2-dev and libxslt1-dev required by anything else we have? If so, my comment is in the wrong place and I'll move it.
