### PR TITLE
Use gawk for adding timestamps to openconnect logs

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -36,11 +36,11 @@ python::version:    '2.7'
 python::dev:        true
 python::virtualenv: true
 
-# These packages are only required for building Transactions Explorer
 system_packages:
     - libxml2-dev
     - libxslt1-dev
     - libffi-dev
+    - gawk
 
 ufw_rules:
     allowhttpfromall:

--- a/modules/openconnect/templates/openconnect.conf.erb
+++ b/modules/openconnect/templates/openconnect.conf.erb
@@ -18,4 +18,4 @@ exec cat /etc/openconnect/network.passwd | openconnect \
   --CAfile /etc/openconnect/network.cacerts \
 <% end -%>
   --user <%= @user -%> \
-  --passwd-on-stdin | awk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0; fflush(); }'
+  --passwd-on-stdin | gawk '{ print strftime("%Y-%m-%dT%H:%M:%S%Z"), $0; fflush(); }'


### PR DESCRIPTION
Ubuntu uses mawk by default and mawk doesn't offer strftime.
Also change timestamp format to be ISO8601 to better match the format
used elsewhere (syslog for example).
