### PR TITLE
Increase the body size for backdrop.write

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -22,10 +22,11 @@ gunicorn_apps:
     user:       'deploy'
     group:      'deploy'
   write.backdrop:
-    port:       3039
-    app_module: 'backdrop.write.api:app'
-    user:       'deploy'
-    group:      'deploy'
+    port:                 3039
+    app_module:           'backdrop.write.api:app'
+    user:                 'deploy'
+    group:                'deploy'
+    client_max_body_size: '30m'
   stagecraft:
     port:            3204
     app_module:      'stagecraft.wsgi:application'

--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -57,6 +57,7 @@ vhost_proxies:
     servername:    "write.backdrop"
     upstream_port: 3039
     proxy_append_forwarded_host: true
+    client_max_body_size: '30m'
   backdrop_admin:
     servername:    "admin.backdrop"
     upstream_port: 3203
@@ -68,6 +69,7 @@ vhost_proxies:
   www:
     servername:    "%{::www_vhost}"
     upstream_port: 7999
+    client_max_body_size: '30m'
   admin:
     servername:    "%{::admin_vhost}"
     upstream_port: 7999

--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -51,6 +51,7 @@ vhost_proxies:
     four_critical: 3
     five_warning: 0
     five_critical: 1
+    client_max_body_size: '30m'
     magic: |
       gzip on;
       gzip_types application/x-javascript application/javascript application/json text/css;

--- a/modules/performanceplatform/manifests/app.pp
+++ b/modules/performanceplatform/manifests/app.pp
@@ -14,6 +14,7 @@ define performanceplatform::app (
   $upstart_desc = "Upstart job for ${title}",
   $upstart_exec = "${app_path}/run-procfile.sh",
   $proxy_append_forwarded_host = false,
+  $client_max_body_size = '10m',
 ) {
   include nginx::server
   include upstart
@@ -35,6 +36,7 @@ define performanceplatform::app (
     ssl           => $proxy_ssl,
     magic         => $magic,
     proxy_append_forwarded_host => $proxy_append_forwarded_host,
+    client_max_body_size => $client_max_body_size,
   }
 
   $base_environment = {

--- a/modules/performanceplatform/manifests/gunicorn_app.pp
+++ b/modules/performanceplatform/manifests/gunicorn_app.pp
@@ -5,6 +5,7 @@ define performanceplatform::gunicorn_app (
   $app_module  = undef,
   $user        = undef,
   $group       = undef,
+  $client_max_body_size = '10m',
 ) {
   # app_path is defined here so that the virtualenv can be
   # created in the correct place
@@ -22,6 +23,7 @@ define performanceplatform::gunicorn_app (
     config_path  => $config_path,
     upstart_desc => $description,
     upstart_exec => "${virtualenv_path}/bin/gunicorn -c ${config_path}/gunicorn ${app_module}",
+    client_max_body_size => $client_max_body_size,
   }
 
   python::virtualenv { $virtualenv_path:


### PR DESCRIPTION
We have been hitting the limits for body size when POSTing to backdrop
write so I have bumped the sizes allowed to 30MB
