### PR TITLE
Re-enable proxy-append-forwarded-host for Backdrop

### DIFF
--- a/modules/performanceplatform/manifests/gunicorn_app.pp
+++ b/modules/performanceplatform/manifests/gunicorn_app.pp
@@ -23,6 +23,7 @@ define performanceplatform::gunicorn_app (
     config_path  => $config_path,
     upstart_desc => $description,
     upstart_exec => "${virtualenv_path}/bin/gunicorn -c ${config_path}/gunicorn ${app_module}",
+    proxy_append_forwarded_host => true,
     client_max_body_size => $client_max_body_size,
   }
 


### PR DESCRIPTION
The backdrop admin app is broken - on sign-in it issues a 302 redirect to
http://admin.backdrop rather than
http://admin.performance.service.gov.uk

Suspect this is due to losing the `proxy_append_forwarded_host` config
parameter in the refactoring that occurred in this pull request:
https://github.com/alphagov/pp-puppet/pull/253

See https://www.pivotaltracker.com/story/show/66497844 [#66497844]
