### PR TITLE
Bump gunicorn timeout for write.backdrop

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -27,6 +27,7 @@ gunicorn_apps:
     user:                 'deploy'
     group:                'deploy'
     client_max_body_size: '30m'
+    timeout:              60
   stagecraft:
     port:            3204
     app_module:      'stagecraft.wsgi:application'

--- a/modules/performanceplatform/manifests/gunicorn_app.pp
+++ b/modules/performanceplatform/manifests/gunicorn_app.pp
@@ -2,6 +2,7 @@ define performanceplatform::gunicorn_app (
   $description = $title,
   $port        = undef,
   $workers     = 4,
+  $timeout     = 30,
   $app_module  = undef,
   $user        = undef,
   $group       = undef,

--- a/modules/performanceplatform/templates/gunicorn.erb
+++ b/modules/performanceplatform/templates/gunicorn.erb
@@ -1,4 +1,5 @@
 # Gunicorn config for <%= title %>
 bind="localhost:<%= port %>"
 workers=<%= workers %>
+timeout=<%= timeout %>
 logconfig="/etc/gds/<%= title %>/gunicorn.logging.conf"


### PR DESCRIPTION
We've been having issues with pushing bigger amounts of data that causes
write.backdrop to get restarted by gunicorn because of large payloads.
In order to mitigate this we need to allow the configuration of timeouts
on gunicorn_apps and bump it specifically for write.backdrop
