### PR TITLE
Add CNAME for admin application

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -32,6 +32,10 @@ performanceplatform::jenkins::plugin_hash:
 performanceplatform::kibana::elasticsearch_url: "https://%{::elasticsearch_vhost}"
 performanceplatform::kibana::tarball_url: 'https://download.elasticsearch.org/kibana/kibana/kibana-3.0.0milestone4.tar.gz'
 
+performanceplatform::dns::cnames:
+  - [ "%{::admin_vhost}", "backend" ]
+
+
 python::version:    '2.7'
 python::dev:        true
 python::virtualenv: true


### PR DESCRIPTION
When trying to write smoke tests to verify feature availability, it
transpires that our network is such that the jumpbox where CI runs can't
reach the admin FQDN.

This is an attempt to allow us to run smoke tests per environment _in
each environment_.
