### PR TITLE
Put the assets subdomain behind Varnish

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -194,6 +194,7 @@ performanceplatform::dns::hosts: |
 
 performanceplatform::dns::cnames:
   - [ "%{::assets_vhost}", "frontend" ]
+  - [ "%{::assets_internal_vhost}", "frontend" ]
   - [ "%{::spotlight_vhost}", "frontend" ]
   - [ "%{::www_vhost}", "frontend" ]
 

--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -73,6 +73,7 @@ vhost_proxies:
   admin:
     servername:    "%{::admin_vhost}"
     upstream_port: 7999
+  # For assets
   assets:
     servername:    "%{::assets_vhost}"
     upstream_port: 7999

--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -28,6 +28,18 @@ ufw_rules:
     ip:   'any'
 
 vhost_proxies:
+  assets-varnish-vhost:
+    servername:    "%{::assets_vhost}"
+    ssl:           true
+    ssl_redirect:  true
+    upstream_port: 7999
+    access_logs:
+      '{name}.access.log.json': 'json_event'
+    four_warning: 1
+    four_critical: 3
+    five_warning: 0
+    five_critical: 1
+
   admin-vhost:
     servername:    "%{::admin_vhost}"
     ssl:           true

--- a/manifests/nodes.pp
+++ b/manifests/nodes.pp
@@ -14,6 +14,7 @@ $admin_vhost         = join(['admin',$public_domain_name],'.')
 $assets_vhost        = join(['assets',$public_domain_name],'.')
 $stagecraft_vhost    = join(['stagecraft',$public_domain_name],'.')
 # Private vhosts
+$assets_internal_vhost = 'assets.frontend'
 $deploy_vhost        = join(['deploy',$domain_name],'.')
 $elasticsearch_vhost = join(['elasticsearch', $domain_name], '.')
 $kibana_vhost        = join(['kibana', $domain_name], '.')

--- a/modules/performanceplatform/manifests/assets.pp
+++ b/modules/performanceplatform/manifests/assets.pp
@@ -7,7 +7,7 @@ class performanceplatform::assets (
 ) {
 
   nginx::vhost { 'assets-vhost':
-    servername => $::assets_vhost,
+    servername => $::assets_internal_vhost,
     ssl        => true,
     magic      => template('performanceplatform/assets-vhost.erb'),
   }

--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -68,6 +68,9 @@ backend stagecraft_backend_2 {
     .probe = stagecraft_healthcheck;
 }
 
+backend frontend_app_1 { .host = "frontend-app-1"; }
+backend frontend_app_2 { .host = "frontend-app-2"; }
+
 # Per-host directors, so we can have per-host healthchecks later
 director admin_director round-robin {
     {
@@ -85,7 +88,6 @@ director write_director round-robin {
         .backend = write_backend_2;
     }
 }
-
 director read_director round-robin {
     {
         .backend = read_backend_1;
@@ -94,7 +96,6 @@ director read_director round-robin {
         .backend = read_backend_2;
     }
 }
-
 director stagecraft_director round-robin {
     {
         .backend = stagecraft_backend_1;
@@ -104,10 +105,21 @@ director stagecraft_director round-robin {
     }
 }
 
+# Add a director for the frontend app servers
+# Note that Varnish currently runs on the frontend app servers,
+# so this might pretty much just pass things through.
+director frontend_app round-robin {
+  { .backend = frontend_app_1; }
+  { .backend = frontend_app_2; }
+}
+
 sub vcl_recv {
   # Routing
+  if (req.http.Host ~ "^assets\..*") {
+    set req.http.Host = "<%= scope.lookupvar('::assets_internal_vhost') %>";
+    set req.backend   = frontend_app;
   # Allow all HTTP Methods for admin
-  if (req.http.Host ~ "^admin\..*") {
+  } else if (req.http.Host ~ "^admin\..*") {
     set req.http.Host = "admin.backdrop";
     set req.backend   = admin_director;
   } else if (req.http.Host ~ "^stagecraft\..*") {


### PR DESCRIPTION
VCL! :sparkles: 
- Create a new vhost, 'assets.frontend' (this is what Varnish will connect to)
- Create a new proxy vhost for assets.env.service.gov.uk and make it upstream to Varnish
- Change the assets vhost to listen on the internal hostname rather than the long one
- Add some VCL to tie it all together

I haven't added a healthcheck probe to Varnish for the frontend app servers because Varnish runs on the frontend app servers, and if we can't serve static content then something else is probably a bit wrong.
