### PR TITLE
Run backups on mongo boxes

### DIFF
--- a/hieradata/role-mongo.yaml
+++ b/hieradata/role-mongo.yaml
@@ -1,6 +1,7 @@
 ---
 classes:
   - 'performanceplatform::mongo'
+  - 'performanceplatform::mongo_backup'
 
 ufw_rules:
   allowmongo:

--- a/modules/performanceplatform/manifests/mongo_backup.pp
+++ b/modules/performanceplatform/manifests/mongo_backup.pp
@@ -1,0 +1,68 @@
+# Class: mongo::backup
+#
+# Parameters:
+#   ['backup_dir'] - The directory to use for backups.
+#
+#   ['user']       - User writing out the backups.
+#
+#   ['backup_log'] - The log file to write success/failure of backing up.
+#
+# Requires:
+# - `puppetlabs/stdlib`
+#
+# Sample Usage:
+#   include mongodb::backup
+#
+class performanceplatform::mongo_backup (
+  $backup_dir  = '/var/backups/mongodb',
+  $backup_log_dir  = '/var/log/backups/',
+  $backup_log  = '/var/log/backups/mongodb.log',
+  $user        = 'root',
+) inherits performanceplatform::mongo {
+
+  file {$backup_dir:
+    ensure  => directory,
+    owner   => $user,
+    group   => $user,
+    mode    => '0755',
+  }
+
+  file {$backup_log_dir:
+    ensure  => directory,
+    owner   => $user,
+    group   => $user,
+    mode    => '0755',
+  }
+
+  file {$backup_log:
+    ensure  => present,
+    owner   => $user,
+    group   => $user,
+    mode    => '0777',
+  }
+
+  file { '/usr/local/bin/mongo-backup.sh':
+    ensure  => present,
+    owner   => root,
+    group   => root,
+    mode    => '0755',
+    content => template('performanceplatform/mongo-backup.sh.erb'),
+    require => File[$backup_dir],
+  }
+
+  cron { 'mongo-backup':
+    command => "/usr/local/bin/mongo-backup.sh",
+    user    => $user,
+    hour    => 3,
+    minute  => 0,
+    require => File['/usr/local/bin/mongo-backup.sh'],
+  }
+
+  sensu::check { 'mongodb_backed_up_less_than_24hrs_ago':
+    command  => '/etc/sensu/community-plugins/plugins/files/check-tail.rb -f /var/log/backups/mongodb.log -l 1 -P failed',
+    interval => 86400,
+    handlers => ['default'],
+  }
+
+
+}

--- a/modules/performanceplatform/manifests/mongo_backup.pp
+++ b/modules/performanceplatform/manifests/mongo_backup.pp
@@ -18,7 +18,7 @@ class performanceplatform::mongo_backup (
   $backup_log_dir  = '/var/log/backups/',
   $backup_log  = '/var/log/backups/mongodb.log',
   $user        = 'root',
-) inherits performanceplatform::mongo {
+) {
 
   file {$backup_dir:
     ensure  => directory,

--- a/modules/performanceplatform/templates/mongo-backup.sh.erb
+++ b/modules/performanceplatform/templates/mongo-backup.sh.erb
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+BACKUP_DIR="<%= @backup_dir %>"
+BACKUP_LOG="<%= @backup_log %>"
+
+TODAY=$(date +%F)
+DAY=$(date +%A |tr 'A-Z' 'a-z')
+MONTH=$(date +%B |tr 'A-Z' 'a-z')
+TMP_DIR=$(mktemp -d -p $BACKUP_DIR) || exit 1
+
+mongodump -o "-" |bzip2  > $TMP_DIR/$TODAY.dump.bz
+
+# remove any preëxisting backups with this name, read out from tmp file and then remove TMP_DIR
+test -f $BACKUP_DIR/$TODAY-mongodb-$DAY.tar.gz && rm $BACKUP_DIR/$TODAY-mongodb-$DAY.tar.gz
+tar -C $TMP_DIR -c -f $BACKUP_DIR/$TODAY-mongodb-$DAY.tar `ls $TMP_DIR`
+rm -fr $TMP_DIR
+
+# Write a log entry to show success or failure
+NOW=$(date +"%s")
+if [ -e $BACKUP_DIR/$TODAY-mongodb-$DAY.tar ];
+then
+    echo "SUCCESS: $NOW $BACKUP_DIR/$TODAY-mongodb-$DAY.tar write was successful" >> $BACKUP_LOG
+else
+    echo "FAILURE: $NOW $BACKUP_DIR/$TODAY-mongodb-$DAY.tar write failed" >> $BACKUP_LOG
+fi


### PR DESCRIPTION
Provides a totally chilled out experience via nightly backups
![](http://25.media.tumblr.com/bfec814bba9b14851fe99d1400d03192/tumblr_n19akhEB3R1ql2603o1_500.jpg)
- Currently backs up nightly to the same box mongo is running on
- Writes success/fail line to a log after backing up
- Adds a sensu check to ensure that a backup has run, tailing the log

_NB:_ This is an interim step before getting a proper backups box as described in https://www.pivotaltracker.com/story/show/65578342 and https://www.pivotaltracker.com/story/show/66160874
