### PR TITLE
Add Stagecraft directory on frontend role

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -6,6 +6,7 @@ classes:
   - 'screenshot_as_a_service::app'
   - 'spotlight::app'
   - 'varnish'
+  - 'stagecraft::assets'
 
 # screenshot_as_a_service runs on 3059 and 3060, but 3059
 # is only used from within this app.

--- a/modules/stagecraft/manifests/assets.pp
+++ b/modules/stagecraft/manifests/assets.pp
@@ -1,0 +1,9 @@
+class stagecraft::assets() {
+  file { ["/opt/stagecraft",
+          "/opt/stagecraft/releases",
+          "/opt/stagecraft/shared",
+          "/opt/stagecraft/shared/log"]:
+    ensure => directory,
+    user   => 'deploy'
+  }
+}


### PR DESCRIPTION
We need to deploy Stagecraft to frontend-app-\* in order to dump its
static assets (Django can't serve them itself).

This puppet change it to ensure that the /opt/stagecraft directory
actually exists, lest the deployment job fails.
