### PR TITLE
Fix 2 syntax errors in Varnish config

### DIFF
--- a/modules/varnish/templates/default.vcl.development.erb
+++ b/modules/varnish/templates/default.vcl.development.erb
@@ -54,11 +54,11 @@ sub vcl_recv {
       set req.http.Host = "read.backdrop";
       set req.backend   = read_director;
     } else {
-      error 405 "Method not allowed"
+      error 405 "Method not allowed";
     }
     call redirect_slash;
   } else {
-    error 404 "Not found"
+    error 404 "Not found";
   }
 
   # normalize Accept-Encoding header

--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -150,11 +150,11 @@ sub vcl_recv {
       set req.http.Host = "read.backdrop";
       set req.backend   = read_director;
     } else {
-      error 405 "Method not allowed"
+      error 405 "Method not allowed";
     }
     call redirect_slash;
   } else {
-    error 404 "Not found"
+    error 404 "Not found";
   }
 
   # normalize Accept-Encoding header


### PR DESCRIPTION
Turns out it's even more "C-like" than we realised. Naughty.
