### PR TITLE
HTTP 403 not 401 when the bearer token is missing

### DIFF
--- a/modules/varnish/templates/default.vcl.development.erb
+++ b/modules/varnish/templates/default.vcl.development.erb
@@ -48,7 +48,7 @@ sub vcl_recv {
         set req.http.Host = "write.backdrop";
         set req.backend   = write_director;
       } else {
-        error 401 "Bearer token not set";
+        error 403 "Bearer token not set";
       }
     } else if (req.request ~ "^(GET|HEAD|OPTIONS)$") {
       set req.http.Host = "read.backdrop";

--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -144,7 +144,7 @@ sub vcl_recv {
         set req.http.Host = "write.backdrop";
         set req.backend   = write_director;
       } else {
-        error 401 "Bearer token not set";
+        error 403 "Bearer token not set";
       }
     } else if (req.request ~ "^(GET|HEAD|OPTIONS)$") {
       set req.http.Host = "read.backdrop";


### PR DESCRIPTION
It's more appropriate to return a 403 than a 401 if there's a bearer token problem.

See http://stackoverflow.com/a/6937030
