### PR TITLE
File dependency should have `owner` not `user`

### DIFF
--- a/modules/stagecraft/manifests/assets.pp
+++ b/modules/stagecraft/manifests/assets.pp
@@ -4,6 +4,6 @@ class stagecraft::assets() {
           "/opt/stagecraft/shared",
           "/opt/stagecraft/shared/log"]:
     ensure => directory,
-    user   => 'deploy'
+    owner  => 'deploy'
   }
 }


### PR DESCRIPTION
Fixes currently broken puppet deployment.
