### PR TITLE
Update backup script to make better use of mongodump

### DIFF
--- a/modules/performanceplatform/manifests/mongo_backup.pp
+++ b/modules/performanceplatform/manifests/mongo_backup.pp
@@ -43,8 +43,8 @@ class performanceplatform::mongo_backup (
 
   file { '/usr/local/bin/mongo-backup.sh':
     ensure  => present,
-    owner   => root,
-    group   => root,
+    owner   => $user,
+    group   => $user,
     mode    => '0755',
     content => template('performanceplatform/mongo-backup.sh.erb'),
     require => File[$backup_dir],

--- a/modules/performanceplatform/manifests/mongo_backup.pp
+++ b/modules/performanceplatform/manifests/mongo_backup.pp
@@ -14,10 +14,11 @@
 #   include mongodb::backup
 #
 class performanceplatform::mongo_backup (
-  $backup_dir  = '/var/backups/mongodb',
-  $backup_log_dir  = '/var/log/backups/',
-  $backup_log  = '/var/log/backups/mongodb.log',
-  $user        = 'root',
+  $database       = 'backdrop',
+  $backup_dir     = '/var/backups/mongodb',
+  $backup_log_dir = '/var/log/backups/',
+  $backup_log     = '/var/log/backups/mongodb.log',
+  $user           = 'root',
 ) {
 
   file {$backup_dir:

--- a/modules/performanceplatform/templates/mongo-backup.sh.erb
+++ b/modules/performanceplatform/templates/mongo-backup.sh.erb
@@ -2,24 +2,22 @@
 
 BACKUP_DIR="<%= @backup_dir %>"
 BACKUP_LOG="<%= @backup_log %>"
+DATABASE="<%= @database %>"
 
 TODAY=$(date +%F)
 DAY=$(date +%A |tr 'A-Z' 'a-z')
 MONTH=$(date +%B |tr 'A-Z' 'a-z')
-TMP_DIR=$(mktemp -d -p $BACKUP_DIR) || exit 1
+FILENAME=$TODAY-$DATABASE-$DAY.tar.gz
 
-mongodump -o "-" |bzip2  > $TMP_DIR/$TODAY.dump.bz
-
-# remove any pre-existing backups with this name, read out from tmp file and then remove TMP_DIR
-test -f $BACKUP_DIR/$TODAY-mongodb-$DAY.tar.gz && rm $BACKUP_DIR/$TODAY-mongodb-$DAY.tar.gz
-tar -C $TMP_DIR -c -f $BACKUP_DIR/$TODAY-mongodb-$DAY.tar `ls $TMP_DIR`
-rm -fr $TMP_DIR
+mongodump -d $DATABASE
+tar -czf $BACKUP_DIR/$FILENAME "dump/$DATABASE"
+rm -rf dump
 
 # Write a log entry to show success or failure
 NOW=$(date +"%s")
-if [ -e $BACKUP_DIR/$TODAY-mongodb-$DAY.tar ];
+if [ -e $BACKUP_DIR/$FILENAME ];
 then
-    echo "SUCCESS: $NOW $BACKUP_DIR/$TODAY-mongodb-$DAY.tar write was successful" >> $BACKUP_LOG
+    echo "SUCCESS: $NOW $BACKUP_DIR/$FILENAME write was successful" >> $BACKUP_LOG
 else
-    echo "FAILURE: $NOW $BACKUP_DIR/$TODAY-mongodb-$DAY.tar write failed" >> $BACKUP_LOG
+    echo "FAILURE: $NOW $BACKUP_DIR/$FILENAME write failed" >> $BACKUP_LOG
 fi


### PR DESCRIPTION
- Previously we were creating empty backups
  ![](http://25.media.tumblr.com/tumblr_m9v1pxPPaN1qiwf8po1_500.gif)
- Specify which database to backup (just backdrop for now)
- Write out dump to default dump folder
- `tar gzip` the contents of dump folder and write out in new format that includes db name (e.g. `2014-03-10-backdrop-monday.tar.gz`)
- Clean up afterwards by removing dump dir

_NB:_ mongodump documentation is a bit unclear on this **grumble grumble**
