### PR TITLE
Set WWW-Authenticate header for 401 responses

### DIFF
--- a/modules/varnish/templates/default.vcl.development.erb
+++ b/modules/varnish/templates/default.vcl.development.erb
@@ -48,7 +48,7 @@ sub vcl_recv {
         set req.http.Host = "write.backdrop";
         set req.backend   = write_director;
       } else {
-        error 401 "Bearer token not set";
+        error 1401 "Bearer token not set";
       }
     } else if (req.request ~ "^(GET|HEAD|OPTIONS)$") {
       set req.http.Host = "read.backdrop";
@@ -158,5 +158,8 @@ sub vcl_error {
     set obj.http.Location = obj.response;
     set obj.status = 301;
     return(deliver);
+  } elsif (obj.status == 1401) { #1401 is our internal, needs a Bearer token
+    set obj.http.WWW-Authenticate = "Bearer";
+    set obj.status = 401;
   }
 }

--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -144,7 +144,7 @@ sub vcl_recv {
         set req.http.Host = "write.backdrop";
         set req.backend   = write_director;
       } else {
-        error 401 "Bearer token not set";
+        error 1401 "Bearer token not set";
       }
     } else if (req.request ~ "^(GET|HEAD|OPTIONS)$") {
       set req.http.Host = "read.backdrop";
@@ -254,5 +254,8 @@ sub vcl_error {
     set obj.http.Location = obj.response;
     set obj.status = 301;
     return(deliver);
+  } elsif (obj.status == 1401) { #1401 is our internal, needs a Bearer token
+    set obj.http.WWW-Authenticate = "Bearer";
+    set obj.status = 401;
   }
 }


### PR DESCRIPTION
This is supposed to be a fast shallow check that the request looks okay,
before being handled by a backend service.
