### PR TITLE
Update puppet version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,13 @@
 source 'https://rubygems.org'
 
-gem 'puppet', '3.1.1'
+gem 'puppet', '3.4.3'
 
 group :build do
-    gem 'facter', '1.7.1'
+    gem 'facter', '1.7.5'
     gem 'hiera-puppet-helper'
-    gem 'librarian-puppet', '0.9.13'
+    gem 'librarian-puppet', '0.9.14'
     gem 'puppet-lint', '0.3.2'
     gem 'puppetlabs_spec_helper', '~>0.4'
-    gem 'rake'
+    gem 'rake', '10.1.1'
     gem 'rspec-puppet', '~> 0.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.4)
-    facter (1.7.1)
+    facter (1.7.5)
     hiera (1.2.1)
       json_pure
     hiera-puppet-helper (1.0.1)
@@ -22,7 +22,7 @@ GEM
     open3_backport (0.0.3)
       open4 (~> 1.3.0)
     open4 (1.3.2)
-    puppet (3.1.1)
+    puppet (3.4.3)
       facter (~> 1.6)
       hiera (~> 1.0)
     puppet-lint (0.3.2)
@@ -31,7 +31,7 @@ GEM
       rake
       rspec (>= 2.9.0)
       rspec-puppet (>= 0.1.1)
-    rake (10.1.0)
+    rake (10.1.1)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -48,11 +48,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  facter (= 1.7.1)
+  facter (= 1.7.5)
   hiera-puppet-helper
-  librarian-puppet (= 0.9.13)
-  puppet (= 3.1.1)
+  librarian-puppet (= 0.9.14)
+  puppet (= 3.4.3)
   puppet-lint (= 0.3.2)
   puppetlabs_spec_helper (~> 0.4)
-  rake
+  rake (= 10.1.1)
   rspec-puppet (~> 0.1)

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,6 +1,6 @@
 forge "http://forge.puppetlabs.com"
 
-mod 'attachmentgenie/ssh',        '1.1.0'
+mod 'attachmentgenie/ssh',        '1.2.2'
 mod 'attachmentgenie/ufw',        '1.2.0'
 mod 'dwerder/graphite',           '3.0.1'
 mod 'pdxcat/collectd',            '1.1.0'
@@ -13,7 +13,7 @@ mod 'puppetlabs/stdlib',          '4.1.0'
 mod 'puppetlabs/vcsrepo',         '0.1.2'
 mod 'rodjek/logrotate',           '1.1.1'
 mod 'saz/dnsmasq',                '1.0.1'
-mod 'saz/ntp',                    '2.0.3'
+mod 'saz/ntp',                    '2.2.0'
 mod 'saz/rsyslog',                '2.0.0'
 mod 'sensu/sensu',                '0.7.7'
 mod 'smarchive/archive',          '0.1.1'
@@ -30,7 +30,7 @@ mod 'elasticsearch', :git => 'git://github.com/gds-operations/puppet-elasticsear
 mod 'ext4mount',     :git => 'git://github.com/alphagov/puppet-ext4mount.git',
                      :ref => 'd97f99cc2801b83152b905d1285fa34e689cb499'
 mod 'gstatsd',       :git => 'git://github.com/alphagov/puppet-gstatsd.git',
-                     :ref => 'c7eb9b99c34194d92e9e8494bdeed1b29b43ed60'
+                     :ref => '668e8a061ca477106ce4b0ac44f26aa87badfd8b'
 mod 'harden',        :git => 'git://github.com/alphagov/puppet-harden.git',
                      :ref => '0966c98cc3f54815c9aac0ebe6e900b70f85182d'
 mod 'jenkins',       :git => 'git://github.com/alphagov/puppet-jenkins.git',
@@ -44,7 +44,7 @@ mod 'lvm',           :git => 'git://github.com/puppetlabs/puppetlabs-lvm.git',
 mod 'mongodb',       :git => 'git://github.com/alphagov/puppetlabs-mongodb.git',
                      :ref => 'dc077a209efdf8d80fac40d40fec575b6a0949d2'
 mod 'nginx',         :git => 'git://github.com/alphagov/puppet-nginx.git',
-                     :ref => '490c76104ad14c9c300b618fa298ff39b059091b'
+                     :ref => 'e9a6b6a5999512eb1feb9e3ecd2ea496e7b7c54b'
 mod 'python',        :git => 'git://github.com/stankevich/puppet-python.git',
                      :ref => 'f508b71d534f3c67db12886fa914cb4ef74bbe7a'
 mod 'ssl',           :git => 'git://github.com/alphagov/puppet-ssl.git',

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,7 +1,7 @@
 FORGE
   remote: http://forge.puppetlabs.com
   specs:
-    attachmentgenie/ssh (1.1.0)
+    attachmentgenie/ssh (1.2.2)
       puppetlabs/stdlib (>= 2.2.1)
     attachmentgenie/ufw (1.2.0)
       puppetlabs/stdlib (>= 2.2.1)
@@ -43,13 +43,14 @@ FORGE
     ripienaar/concat (0.2.0)
     rodjek/logrotate (1.1.1)
     saz/dnsmasq (1.0.1)
-    saz/ntp (2.0.3)
+    saz/ntp (2.2.0)
     saz/rsyslog (2.0.0)
     sensu/sensu (0.7.7)
       puppetlabs/apt (>= 0.0.1)
       puppetlabs/stdlib (>= 0.0.1)
     smarchive/archive (0.1.1)
     stahnma/epel (0.0.5)
+    stankevich/python (1.6.6)
     thomasvandoren/redis (0.0.9)
       maestrodev/wget (>= 0.0.0)
       puppetlabs/gcc (>= 0.0.0)
@@ -85,10 +86,11 @@ GIT
 
 GIT
   remote: git://github.com/alphagov/puppet-gstatsd.git
-  ref: c7eb9b99c34194d92e9e8494bdeed1b29b43ed60
-  sha: c7eb9b99c34194d92e9e8494bdeed1b29b43ed60
+  ref: 668e8a061ca477106ce4b0ac44f26aa87badfd8b
+  sha: 668e8a061ca477106ce4b0ac44f26aa87badfd8b
   specs:
     gstatsd (0.1.0)
+      stankevich/python (>= 1.0.0)
 
 GIT
   remote: git://github.com/alphagov/puppet-harden.git
@@ -123,8 +125,8 @@ GIT
 
 GIT
   remote: git://github.com/alphagov/puppet-nginx.git
-  ref: 490c76104ad14c9c300b618fa298ff39b059091b
-  sha: 490c76104ad14c9c300b618fa298ff39b059091b
+  ref: e9a6b6a5999512eb1feb9e3ecd2ea496e7b7c54b
+  sha: e9a6b6a5999512eb1feb9e3ecd2ea496e7b7c54b
   specs:
     nginx (0.0.1)
 
@@ -189,7 +191,7 @@ GIT
 
 DEPENDENCIES
   account (>= 0)
-  attachmentgenie/ssh (= 1.1.0)
+  attachmentgenie/ssh (= 1.2.2)
   attachmentgenie/ufw (= 1.2.0)
   clamav (>= 0)
   curl (>= 0)
@@ -217,7 +219,7 @@ DEPENDENCIES
   python (>= 0)
   rodjek/logrotate (= 1.1.1)
   saz/dnsmasq (= 1.0.1)
-  saz/ntp (= 2.0.3)
+  saz/ntp (= 2.2.0)
   saz/rsyslog (= 2.0.0)
   sensu/sensu (= 0.7.7)
   smarchive/archive (= 0.1.1)


### PR DESCRIPTION
Ruby 2.x builds fail at the moment. We'd probably like to get there
at some point. This will take us closer to that.
