### PR TITLE
Fix X-Forwarded-{Host,Server} headers for Stagecraft

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -33,6 +33,7 @@ gunicorn_apps:
     app_module:      'stagecraft.wsgi:application'
     user:            'deploy'
     group:           'deploy'
+    is_django:       true
 
 backdrop_collectors:
   backdrop-ga-collector:

--- a/modules/performanceplatform/manifests/app.pp
+++ b/modules/performanceplatform/manifests/app.pp
@@ -14,6 +14,7 @@ define performanceplatform::app (
   $upstart_desc = "Upstart job for ${title}",
   $upstart_exec = "${app_path}/run-procfile.sh",
   $proxy_append_forwarded_host = false,
+  $proxy_set_forwarded_host = false,
   $client_max_body_size = '10m',
 ) {
   include nginx::server
@@ -36,6 +37,7 @@ define performanceplatform::app (
     ssl                         => $proxy_ssl,
     magic                       => $magic,
     proxy_append_forwarded_host => $proxy_append_forwarded_host,
+    proxy_set_forwarded_host    => $proxy_set_forwarded_host,
     client_max_body_size        => $client_max_body_size,
   }
 

--- a/modules/performanceplatform/manifests/gunicorn_app.pp
+++ b/modules/performanceplatform/manifests/gunicorn_app.pp
@@ -7,12 +7,21 @@ define performanceplatform::gunicorn_app (
   $user        = undef,
   $group       = undef,
   $client_max_body_size = '10m',
+  $is_django   = false,
 ) {
   # app_path is defined here so that the virtualenv can be
   # created in the correct place
   $app_path        = "/opt/${title}"
   $config_path     = "/etc/gds/${title}"
   $virtualenv_path = "${app_path}/shared/venv"
+
+  if $is_django {
+    $proxy_append_forwarded_host = false
+    $proxy_set_forwarded_host = true
+  } else {
+    $proxy_append_forwarded_host = true
+    $proxy_set_forwarded_host = false
+  }
 
   performanceplatform::app { $title:
     port                        => $port,
@@ -24,7 +33,8 @@ define performanceplatform::gunicorn_app (
     config_path                 => $config_path,
     upstart_desc                => $description,
     upstart_exec                => "${virtualenv_path}/bin/gunicorn -c ${config_path}/gunicorn ${app_module}",
-    proxy_append_forwarded_host => true,
+    proxy_append_forwarded_host => $proxy_append_forwarded_host,
+    proxy_set_forwarded_host    => $proxy_set_forwarded_host,
     client_max_body_size        => $client_max_body_size,
   }
 

--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -17,6 +17,7 @@ define performanceplatform::proxy_vhost(
   $proxy               = true,
   $proxy_magic         = '',
   $proxy_append_forwarded_host = false,
+  $proxy_set_forwarded_host = false,
   $forward_host_header = true,
   $client_max_body_size = '10m',
   $access_logs          = { '{name}.access.log' => '' },


### PR DESCRIPTION
Django doesn't support multiple, comma separated host names in the X-Forwarded headers.
https://code.djangoproject.com/ticket/9064
- Add a flag to `performanceplatform::gunicorn_app` to describe an app as a Django app.
- Configure Stagecraft to be a Django app.
