### PR TITLE
Fix varnish check for Bearer token presence

### DIFF
--- a/modules/varnish/templates/default.vcl.development.erb
+++ b/modules/varnish/templates/default.vcl.development.erb
@@ -51,7 +51,7 @@ sub vcl_recv {
         set req.http.Host = "write.backdrop";
         set req.backend   = write_backend;
       } else {
-        error 1401 "Bearer token not set";
+        error 671 "Bearer token not set";
       }
     } else if (req.request ~ "^(GET|HEAD|OPTIONS)$") {
       set req.http.Host = "read.backdrop";
@@ -161,8 +161,9 @@ sub vcl_error {
     set obj.http.Location = obj.response;
     set obj.status = 301;
     return(deliver);
-  } elsif (obj.status == 1401) { #1401 is our internal, needs a Bearer token
+  } elsif (obj.status == 671) { #671 is our internal, needs a Bearer token
     set obj.http.WWW-Authenticate = "Bearer";
     set obj.status = 401;
+    return(deliver);
   }
 }

--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -144,7 +144,7 @@ sub vcl_recv {
         set req.http.Host = "write.backdrop";
         set req.backend   = write_director;
       } else {
-        error 1401 "Bearer token not set";
+        error 671 "Bearer token not set";
       }
     } else if (req.request ~ "^(GET|HEAD|OPTIONS)$") {
       set req.http.Host = "read.backdrop";
@@ -254,8 +254,9 @@ sub vcl_error {
     set obj.http.Location = obj.response;
     set obj.status = 301;
     return(deliver);
-  } elsif (obj.status == 1401) { #1401 is our internal, needs a Bearer token
+  } elsif (obj.status == 671) { #671 is our internal, needs a Bearer token
     set obj.http.WWW-Authenticate = "Bearer";
     set obj.status = 401;
+    return(deliver);
   }
 }


### PR DESCRIPTION
Varnish has an undocumented acceptable range of values that can be passed as
the code to the error built-in function. 1401 is outside of that range.

See
https://github.com/varnish/Varnish-Cache/blob/5cf517e858b212a37a106a8ae78ffabe13a0dd5b/bin/varnishd/cache/cache_vrt.c#L62-L63
