### PR TITLE
Fix stagecraft redirect bug

### DIFF
--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -88,6 +88,7 @@ define performanceplatform::proxy_vhost(
     proxy                       => $proxy,
     proxy_magic                 => $proxy_magic,
     proxy_append_forwarded_host => $proxy_append_forwarded_host,
+    proxy_set_forwarded_host    => $proxy_set_forwarded_host,
     forward_host_header         => $forward_host_header,
     client_max_body_size        => $client_max_body_size,
     access_logs                 => $access_logs,

--- a/modules/performanceplatform/spec/defines/gunicorn_app_spec.rb
+++ b/modules/performanceplatform/spec/defines/gunicorn_app_spec.rb
@@ -3,6 +3,7 @@ require_relative '../../../../spec_helper'
 describe 'performanceplatform::gunicorn_app', :type => :define do
   let(:title) { 'gunicorn-app' }
   let(:hiera_data) {{
+    'lumberjack::hosts'          => [],
     'ssl::params::ssl_path'      => 'test.gov.uk',
     'ssl::params::ssl_cert_file' => 'testtest',
     'ssl::params::ssl_key_file'  => 'testest',

--- a/modules/performanceplatform/spec/defines/gunicorn_app_spec.rb
+++ b/modules/performanceplatform/spec/defines/gunicorn_app_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../../../../spec_helper'
+
+describe 'performanceplatform::gunicorn_app', :type => :define do
+  let(:title) { 'gunicorn-app' }
+  let(:hiera_data) {{
+    'ssl::params::ssl_path'      => 'test.gov.uk',
+    'ssl::params::ssl_cert_file' => 'testtest',
+    'ssl::params::ssl_key_file'  => 'testest',
+  }}
+  let(:facts) {{
+    :operatingsystem => 'ubuntu',
+  }}
+  
+  context 'is a django app that' do
+    let(:params) {{
+      'is_django' => true,
+    }}
+  
+    it do
+      should contain_nginx__vhost__proxy('gunicorn-app-vhost').with(
+        'proxy_set_forwarded_host' => true,
+        'proxy_append_forwarded_host' => false,
+      )
+    end
+
+  end
+
+  context 'is a non-django app that' do
+    let(:params) {{
+      'is_django' => false,
+    }}
+    it do
+      should contain_nginx__vhost__proxy('gunicorn-app-vhost').with(
+        'proxy_set_forwarded_host' => false,
+        'proxy_append_forwarded_host' => true,
+      )
+    end
+  end
+end


### PR DESCRIPTION
[fixes #67770984]
https://www.pivotaltracker.com/story/show/67770984

The proxy_set_forwarded_host argument was not being passed down from
`performanceplatform::proxy_vhost` to `nginx::vhost::proxy`
