### PR TITLE
Fix Stagecraft redirect bug

### DIFF
--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -88,6 +88,7 @@ define performanceplatform::proxy_vhost(
     proxy                       => $proxy,
     proxy_magic                 => $proxy_magic,
     proxy_append_forwarded_host => $proxy_append_forwarded_host,
+    proxy_set_forwarded_host    => $proxy_set_forwarded_host,
     forward_host_header         => $forward_host_header,
     client_max_body_size        => $client_max_body_size,
     access_logs                 => $access_logs,


### PR DESCRIPTION
[fixes #67770984] https://www.pivotaltracker.com/story/show/67770984

The proxy_set_forwarded_host argument was not being passed down from 
performanceplatform::proxy_vhost to nginx::vhost::proxy
