### PR TITLE
Add createdb to stagecraft postgres user on dev

### DIFF
--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -3,6 +3,7 @@ classes:
   - 'clamav'
   - 'google_credentials'
   - 'nginx::server'
+  - 'performanceplatform::development'
   - 'performanceplatform::mongo'
   - 'performanceplatform::nodejs'
   - 'performanceplatform::postgresql_primary'

--- a/modules/performanceplatform/manifests/development.pp
+++ b/modules/performanceplatform/manifests/development.pp
@@ -1,0 +1,5 @@
+class performanceplatform::development {
+  postgresql::server::role { 'stagecraft':
+    createdb => true,
+  }
+}


### PR DESCRIPTION
This allows stagecraft tests to be run against postgres on the
development role. This is required by Django as it destroys the database
and recreates it on each test run.

Related to https://www.pivotaltracker.com/story/show/67841906 [#67841906]
