### PR TITLE
Add logrotate rule to nginx JSON logs

### DIFF
--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -69,6 +69,18 @@ define performanceplatform::proxy_vhost(
     $magic_with_pp_only = $magic
   }
 
+  logrotate::rule { "${title}-json-logs":
+    path         => "/var/log/nginx/*.log.json",
+    rotate       => 30,
+    rotate_every => 'day',
+    missingok    => true,
+    compress     => true,
+    create       => true,
+    create_mode  => '0640',
+    create_owner => $user,
+    create_group => $group,
+  }
+
   nginx::vhost::proxy { $name:
     port                        => $port,
     priority                    => $priority,


### PR DESCRIPTION
**This is not ready to merge. I don't know what I'm doing so this pull request is more to get people to remember to do something with these files.**

Nginx JSON access and error logs are at about 2GB in size on the jumpbox.

```
root@jumpbox-1:/var/log/nginx# ls -alh | grep G
total 3.1G
-rw-r--r--  1 www-data root 1.9G Mar 24 15:46 alerts.production.performance.service.gov.uk.access.log.json
-rw-r--r--  1 www-data root 1.2G Mar 24 15:46 graphite.production.performance.service.gov.uk.access.log.json
```
