### PR TITLE
Tidy up JSON log rotate rule

### DIFF
--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -70,7 +70,7 @@ define performanceplatform::proxy_vhost(
   }
 
   logrotate::rule { "${title}-json-logs":
-    path         => "/var/log/nginx/*.log.json",
+    path         => "/var/log/nginx/${servername}.*.log.json",
     rotate       => 30,
     rotate_every => 'day',
     missingok    => true,
@@ -79,6 +79,7 @@ define performanceplatform::proxy_vhost(
     create_mode  => '0640',
     create_owner => $user,
     create_group => $group,
+    postrotate   => 'service nginx rotate',
   }
 
   nginx::vhost::proxy { $name:

--- a/modules/varnish/LICENCE.txt
+++ b/modules/varnish/LICENCE.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2011 HM Government (Government Digital Service)
+Copyright (C) 2014 HM Government (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/modules/varnish/README.md
+++ b/modules/varnish/README.md
@@ -1,4 +1,1 @@
-[pp-puppet-varnish](https://github.com/alphagov/puppet-pp-varnish)
-======
-
-Puppet module for installing Varnish and configuring it for Performance Platform
+Puppet module for installing Varnish and configuring it for the Performance Platform.


### PR DESCRIPTION
- Change path to specify a unique servername per logrotate rule
- Add postrotate rule to rotate nginx logs
