### PR TITLE
Add sensu check for Stagecraft healthcheck

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -4,6 +4,7 @@ classes:
   - 'clamav'
   - 'google_credentials'
   - 'performanceplatform::checks::backdrop'
+  - 'performanceplatform::checks::stagecraft'
   - 'performanceplatform::backdrop_smoke_tests'
   - 'performanceplatform::pip'
   - 'python'

--- a/modules/performanceplatform/manifests/checks/stagecraft.pp
+++ b/modules/performanceplatform/manifests/checks/stagecraft.pp
@@ -1,0 +1,16 @@
+class performanceplatform::checks::stagecraft (
+) {
+    $check_data_path = '/etc/sensu/community-plugins/plugins/http/check-http.rb'
+
+    sensu::check { "stagecraft_basic_status_health_check":
+      interval => 120,
+      command  => "${check_data_path}  -u http://localhost:3204/_status",
+      handlers => ['default'],
+    }
+
+    sensu::check { "stagecraft_access_data_sets_health_check":
+      interval => 120,
+      command  => "${check_data_path}  -u http://localhost:3204/_status/data-sets",
+      handlers => ['default'],
+    }
+}


### PR DESCRIPTION
So that we actually get alerted if it goes down. Mostly adapted from 
backdrop's sensu checks.

Status endpoint code in stagecraft:
- https://github.com/alphagov/stagecraft/pull/64
- https://github.com/alphagov/stagecraft/pull/90

See https://www.pivotaltracker.com/story/show/58614078 [#58614078]
