### PR TITLE
Increase Spotlight assets cache time to 1 month

### DIFF
--- a/modules/performanceplatform/templates/assets-vhost.erb
+++ b/modules/performanceplatform/templates/assets-vhost.erb
@@ -1,7 +1,7 @@
 # Spotlight serves assets from the public directory
 # of the currently deployed version of the app.
 location /spotlight/ {
-  expires 1d;
+  expires 1m;
   rewrite ^/spotlight(.*)$ $1 break;
   root /opt/spotlight/current/public;
   gzip on;


### PR DESCRIPTION
When we deploy applications, we frequently see issues where the page is rendered without assets.

Initially we thought Varnish was working incorrectly, but actually I think the issue is that the files are not in the cache on both frontend app servers, which means that we respond with a 404 in some cases.

If the file is in Varnish on only one frontend app server, and somebody who does not have the page cached locally makes a request that hits the other frontend app server, they'll get a 404.

An easy way to fix this is to increase the cache time to a month, which we can do now because everything is being properly cachebusted.
