### PR TITLE
Fix deprecation notices in gunicorn.logging config

### DIFF
--- a/modules/performanceplatform/templates/gunicorn.logging.conf.erb
+++ b/modules/performanceplatform/templates/gunicorn.logging.conf.erb
@@ -31,22 +31,22 @@ args=(sys.stdout, )
 [handler_error_file]
 class=logging.FileHandler
 formatter=generic
-args=('/var/log/<%= title %>/gunicorn.error.log',)
+args=('/var/log/<%= @title %>/gunicorn.error.log',)
 
 [handler_error_json_file]
 class=logging.FileHandler
 formatter=logstash
-args=('/var/log/<%= title %>/gunicorn.error.log.json',)
+args=('/var/log/<%= @title %>/gunicorn.error.log.json',)
 
 [handler_access_file]
 class=logging.FileHandler
 formatter=access
-args=('/var/log/<%= title %>/gunicorn.access.log',)
+args=('/var/log/<%= @title %>/gunicorn.access.log',)
 
 [handler_access_json_file]
 class=logging.FileHandler
 formatter=logstash
-args=('/var/log/<%= title %>/gunicorn.access.log.json',)
+args=('/var/log/<%= @title %>/gunicorn.access.log.json',)
 
 [formatter_generic]
 format=%(asctime)s [%(process)d] [%(levelname)s] %(message)s


### PR DESCRIPTION
```
Warning: Variable access via 'title' is deprecated. Use '@title' instead.
```
