### PR TITLE
Fix cache time for Spotlight assets

### DIFF
--- a/modules/performanceplatform/templates/assets-vhost.erb
+++ b/modules/performanceplatform/templates/assets-vhost.erb
@@ -1,7 +1,7 @@
 # Spotlight serves assets from the public directory
 # of the currently deployed version of the app.
 location /spotlight/ {
-  expires 1m;
+  expires 30d;
   rewrite ^/spotlight(.*)$ $1 break;
   root /opt/spotlight/current/public;
   gzip on;


### PR DESCRIPTION
`1m` is 1 minute, not 1 month. `30d` is 30 days, which is 1 month.

See also #303.
