### PR TITLE
Use a hiera lookup instead of a non-existant global to restrict access

### DIFF
--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -63,8 +63,9 @@ define performanceplatform::proxy_vhost(
     }
   }
 
-  $gds_only = hiera('pp_only_vhost')
-  if $gds_only {
+  # Restrict access beyond GDS ips
+  if $pp_only_vhost {
+    $gds_only = hiera('pp_only_vhost')
     $magic_with_pp_only = "${magic}${gds_only}"
   } else {
     $magic_with_pp_only = $magic

--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -63,8 +63,9 @@ define performanceplatform::proxy_vhost(
     }
   }
 
-  if $pp_only_vhost {
-    $magic_with_pp_only = "${magic}${::pp_only_vhost}"
+  $gds_only = hiera('pp_only_vhost')
+  if $gds_only {
+    $magic_with_pp_only = "${magic}${gds_only}"
   } else {
     $magic_with_pp_only = $magic
   }


### PR DESCRIPTION
- Should restrict access to the outside world (not in Aviation house)
- We were never setting `::pp_only_vhost` in the global namespace
- hiera lookup should work on a per-environment basis
- Tested in VM, #TODO write a test around this!
- Should fix https://www.pivotaltracker.com/story/show/67090622
