### PR TITLE
Use the same set of dnsmasq cnames everywhere

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -194,6 +194,7 @@ performanceplatform::dns::hosts: |
   172.27.1.71 backup-box-1
 
 performanceplatform::dns::cnames:
+  - [ "%{::admin_vhost}", "frontend" ]
   - [ "%{::assets_vhost}", "frontend" ]
   - [ "%{::assets_internal_vhost}", "frontend" ]
   - [ "%{::spotlight_vhost}", "frontend" ]

--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -32,11 +32,6 @@ performanceplatform::jenkins::plugin_hash:
 performanceplatform::kibana::elasticsearch_url: "https://%{::elasticsearch_vhost}"
 performanceplatform::kibana::tarball_url: 'https://download.elasticsearch.org/kibana/kibana/kibana-3.0.0milestone4.tar.gz'
 
-performanceplatform::dns::cnames:
-  - [ "%{::admin_vhost}", "frontend" ]
-  - [ "%{::stagecraft_vhost}", "frontend" ]
-  - [ "%{::www_vhost}", "frontend" ]
-
 
 python::version:    '2.7'
 python::dev:        true


### PR DESCRIPTION
Before we had a different set of cnames used on the jumpbox. It was
unclear why and caused pp-smokey to fail.
