### PR TITLE
Set password when creating dev postgres role

### DIFF
--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -108,3 +108,6 @@ ppas:
   - 'ppa:teward/nginx-devel-testing'
 
 nginx::server::version: 'latest'
+
+# Same as performanceplatform::postgresql_primary::stagecraft_password
+performanceplatform::development::stagecraft_password: "securem8"

--- a/modules/performanceplatform/manifests/development.pp
+++ b/modules/performanceplatform/manifests/development.pp
@@ -1,5 +1,8 @@
-class performanceplatform::development {
+class performanceplatform::development (
+  $stagecraft_password
+) {
   postgresql::server::role { 'stagecraft':
     createdb => true,
+    password_hash => postgresql_password('stagecraft', $stagecraft_password),
   }
 }


### PR DESCRIPTION
When creating the stagecraft postgres role in development we need to
also provide the password.
