### PR TITLE
Varnish caching

### DIFF
--- a/modules/varnish/templates/default.vcl.development.erb
+++ b/modules/varnish/templates/default.vcl.development.erb
@@ -96,6 +96,15 @@ sub vcl_recv {
       error 200 "Purged";
     }
   }
+
+  # Usually, varnish would refuse to cache requests with an Authorization
+  # header. We cache these and use the Vary header to prevent serving
+  # private content to unauthorised clients.
+  if (req.request == "GET" || req.request == "HEAD") {
+    if (req.http.Authorization) {
+      return(lookup);
+    }
+  }
 }
 
 sub vcl_fetch {
@@ -138,7 +147,7 @@ sub vcl_fetch {
       return(restart);
     }
   }
-
+  return(deliver);
 }
 
 sub vcl_hash {

--- a/modules/varnish/templates/default.vcl.development.erb
+++ b/modules/varnish/templates/default.vcl.development.erb
@@ -1,7 +1,7 @@
 # Varnish will append its default logic to any overwritten subroutine. If
 # you're not sure what that is, see here:
 #
-#   https://www.varnish-cache.org/trac/browser/bin/varnishd/default.vcl?rev=2.0
+#   https://www.varnish-cache.org/trac/browser/bin/varnishd/default.vcl?rev=3.0
 
 acl purge_acl {
   "localhost";

--- a/modules/varnish/templates/default.vcl.development.erb
+++ b/modules/varnish/templates/default.vcl.development.erb
@@ -42,7 +42,6 @@ sub vcl_recv {
     call redirect_slash;
   } else if (req.http.Host ~ "^stagecraft\..*") {
     # Send stagecraft requests to stagecraft
-    set req.http.Host = "stagecraft";
     set req.backend   = stagecraft_backend;
   } else if (req.http.Host ~ "^www\..*") {
     # Send www requests to backdrop

--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -1,7 +1,7 @@
 # Varnish will append its default logic to any overwritten subroutine. If
 # you're not sure what that is, see here:
 #
-#   https://www.varnish-cache.org/trac/browser/bin/varnishd/default.vcl?rev=2.0
+#   https://www.varnish-cache.org/trac/browser/bin/varnishd/default.vcl?rev=3.0
 
 acl purge_acl {
   "localhost";

--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -190,6 +190,15 @@ sub vcl_recv {
       error 200 "Purged";
     }
   }
+
+  # Usually, varnish would refuse to cache requests with an Authorization
+  # header. We cache these and use the Vary header to prevent serving
+  # private content to unauthorised clients.
+  if (req.request == "GET" || req.request == "HEAD") {
+    if (req.http.Authorization) {
+      return(lookup);
+    }
+  }
 }
 
 sub vcl_fetch {
@@ -232,7 +241,7 @@ sub vcl_fetch {
       return(restart);
     }
   }
-
+  return(deliver);
 }
 
 sub vcl_hash {


### PR DESCRIPTION
By default Varnish will not cache any requests with a Cookie or an
Authorization header. This change tells Varnish to lookup GET or HEAD
requests if the Authorization header is set.

This obviously raises the risk of sending a cached response to an
unauthorised client. This is mitigated by the backend app sending a Vary
header set to 'Authorized'.
