### PR TITLE
Make PostgreSQL backups readable with chmod

### DIFF
--- a/modules/performanceplatform/templates/pgsql-backup.sh.erb
+++ b/modules/performanceplatform/templates/pgsql-backup.sh.erb
@@ -13,6 +13,7 @@ export PGUSER=postgres
 pg_dumpall --clean --oids |gzip > ${TMP_FILE}
 
 mv ${TMP_FILE} ${BACKUP_FILE}
+chmod +r ${BACKUP_FILE}
 
 # clean backups older than 30 days
 


### PR DESCRIPTION
So that our deploy user can fish them off the box and copy them to the 
backups box.
