### PR TITLE
Add an ackrc to ignore vendor and .tmp

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -1,0 +1,2 @@
+--ignore-dir=vendor
+--ignore-dir=.tmp


### PR DESCRIPTION
Most of the time when using ack we don't want to search through these
directories.
