### PR TITLE
Rename `data_dir` to `backup_dir`

### DIFF
--- a/hieradata/role-backup-box.yaml
+++ b/hieradata/role-backup-box.yaml
@@ -2,5 +2,5 @@
 classes:
   - 'performanceplatform::backup_box'
 
-performanceplatform::backup_box::data_dir: '/mnt/data/backup'
+performanceplatform::backup_box::backup_dir: '/mnt/data/backup'
 performanceplatform::backup_box::disk_mount: '/dev/mapper/data-backup'

--- a/modules/performanceplatform/manifests/backup_box.pp
+++ b/modules/performanceplatform/manifests/backup_box.pp
@@ -2,7 +2,7 @@
 #
 #
 class performanceplatform::backup_box(
-    $data_dir,
+    $backup_dir,  # directory inside /mnt/data
     $disk_mount,
 ) {
 
@@ -25,7 +25,7 @@ class performanceplatform::backup_box(
         ensure => directory,
     }
 
-    performanceplatform::mount { $data_dir:
+    performanceplatform::mount { $backup_dir:
         mountoptions => 'defaults',
         disk         => $disk_mount,
         require      => File['/mnt/data'],

--- a/modules/performanceplatform/spec/classes/backup_box_spec.rb
+++ b/modules/performanceplatform/spec/classes/backup_box_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../../../spec_helper'
 describe 'performanceplatform::backup_box', :type => :class do
 
     let (:params) {{
-        'data_dir'      => '/mnt/data/backup',
+        'backup_dir'    => '/mnt/data/backup',
         'disk_mount'    => '/dev/mapper/data-backup',
     }}
 


### PR DESCRIPTION
The variable is referring to `/mnt/data/backup` - calling it `data_dir` made
me think it was the `/mnt/data` part. I think `backup_dir` is a more accurate
name.
