### PR TITLE
In Travis, don't build `build_*` tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,6 @@ matrix:
   allow_failures:
     - rvm: 2.0.0
     - rvm: 2.1.1
+branches:
+  except:
+    - /^build_\d+$/


### PR DESCRIPTION
It's wasteful, we don't ever see the output of these builds.
