### PR TITLE
Add CMake to jumpbox

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -38,6 +38,7 @@ python::dev:        true
 python::virtualenv: true
 
 system_packages:
+    - cmake
     - libxml2-dev
     - libxslt1-dev
     - libffi-dev


### PR DESCRIPTION
Inorder to install the dependencies of cheapseats, our config based
smoketests, we need CMake to be installed (for libgit2).
