### PR TITLE
Fix string concatenation

### DIFF
--- a/modules/performanceplatform/manifests/backup_box.pp
+++ b/modules/performanceplatform/manifests/backup_box.pp
@@ -31,13 +31,13 @@ class performanceplatform::backup_box(
         require      => File['/mnt/data'],
     }
 
-    file { $backup_dir + '/postgresql':
+    file { "${backup_dir}/postgresql":
         ensure => directory,
         owner  => 'deploy',
         require => [Performanceplatform::Mount[$backup_dir]],
     }
 
-    file { $backup_dir + '/mongodb':
+    file { "${backup_dir}/mongodb":
         ensure => directory,
         owner  => 'deploy',
         require => [Performanceplatform::Mount[$backup_dir]],


### PR DESCRIPTION
Turns out `$var + "foo"` isn't OK :(
