### PR TITLE
Add run_tests.sh and make travis.yml explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ before_install:
   - gem install puppet
   - gem install librarian-puppet
   - librarian-puppet install
+script:
+  - ./run_tests.sh
 notifications:
   email: false
 matrix:

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+set -o pipefail
+
+bundle exec rake || echo "FAIL." && false


### PR DESCRIPTION
- We use `run_tests.sh` elsewhere so it's consistent.
- On my machine, when `bundle exec rake` fails it does so with no
  output, so it's not at all clear that it has failed!
- It's weird that `.travis.yml` magically runs rake because it's a
  ruby project - better to be explicit.
