### PR TITLE
Simplify test runner

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,3 @@
 #!/bin/bash -e
 
-set -o pipefail
-
-bundle exec rake || echo "FAIL." && false
+bundle exec rake


### PR DESCRIPTION
It was returning nonzero exit code even when the tests were passing. Bash fu.
Make it simple.
