### PR TITLE
Make Jenkins .bash_profile source .bashrc

### DIFF
--- a/modules/performanceplatform/files/jenkins-bash_profile
+++ b/modules/performanceplatform/files/jenkins-bash_profile
@@ -1,0 +1,5 @@
+# http://www.joshstaiger.org/archives/2005/07/bash_profile_vs.html
+
+if [ -f ~/.bashrc ]; then
+   source ~/.bashrc
+fi

--- a/modules/performanceplatform/manifests/deploy.pp
+++ b/modules/performanceplatform/manifests/deploy.pp
@@ -64,5 +64,12 @@ class performanceplatform::deploy (
           mode    => '0700',
           require => Class['jenkins']
         }
+        file { '/var/lib/jenkins/.bash_profile':
+          source  => 'puppet:///modules/performanceplatform/jenkins-bash_profile',
+          owner   => 'jenkins',
+          group   => 'jenkins',
+          mode    => '0700',
+          require => Class['jenkins']
+        }
     }
 }


### PR DESCRIPTION
We've got some functionality in Jenkins' `.bashrc` related to
`keychain`, which makes ssh keys available in ssh-agent (somehow).

We should get this behaviour regardless of how we open a bash shell.

More specifically, we need this stuff in order for us to use SSH agent 
forwarding from Jenkins. We invoke a script with `/bin/bash --login` which
uses `.bash_profile`

See http://www.joshstaiger.org/archives/2005/07/bash_profile_vs.html
