### PR TITLE
Only smoke tests should send pagerduty

### DIFF
--- a/modules/performanceplatform/manifests/checks/server.pp
+++ b/modules/performanceplatform/manifests/checks/server.pp
@@ -22,7 +22,7 @@ define performanceplatform::checks::server (
       warning  => '4000000000:', # A little less than 4 gig
       critical => '1000000000:',  # A little less than 1 gig
       interval => 60,
-      handlers => ['default', 'pagerduty'],
+      handlers => ['default'],
     }
 
     performanceplatform::checks::graphite { "check_machine_is_down_${name}":
@@ -30,6 +30,6 @@ define performanceplatform::checks::server (
       warning  => '0:',
       critical => '0:',
       interval => 60,
-      handlers => ['default', 'pagerduty'],
+      handlers => ['default'],
     }
 }

--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -82,7 +82,7 @@ class performanceplatform::elasticsearch(
   sensu::check { 'elasticsearch_is_out_of_memory':
     command  => '/etc/sensu/community-plugins/plugins/files/check-tail.rb -f /var/log/elasticsearch/elasticsearch.log -l 50 -P OutOfMemory',
     interval => 60,
-    handlers => ['default', 'pagerduty'],
+    handlers => ['default'],
   }
 
   sensu::check { 'elasticsearch_cluster_status':
@@ -99,7 +99,7 @@ class performanceplatform::elasticsearch(
     warning  => '4000000000:', # A little less than 4 gig
     critical => '1000000000:',  # A little less than 1 gig
     interval => 60,
-    handlers => ['default', 'pagerduty'],
+    handlers => ['default'],
   }
 
 }

--- a/modules/performanceplatform/manifests/mongo.pp
+++ b/modules/performanceplatform/manifests/mongo.pp
@@ -59,7 +59,7 @@ rs.initiate(replicaSetConfig());
     sensu::check { "mongod_is_down_${escaped_fqdn}":
       command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p mongod -W 1 -C 1 -w -1 -c -1',
       interval => 60,
-      handlers => ['default', 'pagerduty'],
+      handlers => ['default'],
     }
 
 }

--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -150,7 +150,7 @@ class performanceplatform::monitoring (
   sensu::check { 'logstash_is_down':
     command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p logstash -C 1 -c -1 -w -1 -W 2',
     interval => 60,
-    handlers => ['default', 'pagerduty'],
+    handlers => ['default'],
   }
 
   sensu::handler { 'default':


### PR DESCRIPTION
TOO MUCH NOISE. We should follow the example of GOV.UK and only actively
alert us on the most serious issues. At the moment we seem to be
suffering a little bit of PagerDuty blindness.
