### PR TITLE
Add sensu checks for freshness of backups

### DIFF
--- a/hieradata/role-backup-box.yaml
+++ b/hieradata/role-backup-box.yaml
@@ -1,6 +1,8 @@
 ---
 classes:
   - 'performanceplatform::backup_box'
+  - 'performanceplatform::checks::backups'
+
 
 performanceplatform::backup_box::backup_dir: '/mnt/data/backup'
 performanceplatform::backup_box::disk_mount: '/dev/mapper/data-backup'

--- a/modules/performanceplatform/files/check-directory-freshness.sh
+++ b/modules/performanceplatform/files/check-directory-freshness.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+CHECK_DIRECTORY="$1"
+
+if [ ! -d "${CHECK_DIRECTORY}" ]; then
+    echo "Not a valid directory: ${CHECK_DIRECTORY}"
+    exit 1
+fi
+
+files_found=$(find "${CHECK_DIRECTORY}" -ctime -1 -type f ! -empty)
+
+if [ "${files_found}" = "" ]; then
+    echo "No new files found in ${CHECK_DIRECTORY}"
+    exit 1
+fi
+
+echo "New files found: ${files_found}"
+exit 0

--- a/modules/performanceplatform/manifests/checks/backups.pp
+++ b/modules/performanceplatform/manifests/checks/backups.pp
@@ -1,0 +1,24 @@
+class performanceplatform::checks::backups (
+) {
+    $freshness_script ="/etc/sensu/check-directory-freshness.sh"
+
+    file { $freshness_script:
+      require => Class['sensu'],
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0777',
+      source  => "puppet:///modules/performanceplatform/files/check-directory-freshness.sh"
+    }
+
+    sensu::check { 'postgresql_backups_copy_check':
+      interval => 3600,
+      command  => "${freshness_script} /mnt/data/backups/postgresql",
+      handlers => ['default'],
+    }
+
+    sensu::check { 'mongo_backups_copy_check':
+      interval => 3600,
+      command  => "${freshness_script} /mnt/data/backups/mongodb",
+      handlers => ['default'],
+    }
+}


### PR DESCRIPTION
We generate backups on the Mongo boxes and the PostgreSQL box with a cron
job. These are periodically copied over to the backups box by a Jenkins job.

Here are sensu checks that the mongo and postgresql backup directories on the
backups box always contain files younger than 1 day old (ie that they happen
daily).
