### PR TITLE
Change mapper/data-backup to mapper/backup-data

### DIFF
--- a/hieradata/role-backup-box.yaml
+++ b/hieradata/role-backup-box.yaml
@@ -5,4 +5,4 @@ classes:
 
 
 performanceplatform::backup_box::backup_dir: '/mnt/data/backup'
-performanceplatform::backup_box::disk_mount: '/dev/mapper/data-backup'
+performanceplatform::backup_box::disk_mount: '/dev/mapper/backup-data'

--- a/modules/performanceplatform/spec/classes/backup_box_spec.rb
+++ b/modules/performanceplatform/spec/classes/backup_box_spec.rb
@@ -4,7 +4,7 @@ describe 'performanceplatform::backup_box', :type => :class do
 
     let (:params) {{
         'backup_dir'    => '/mnt/data/backup',
-        'disk_mount'    => '/dev/mapper/data-backup',
+        'disk_mount'    => '/dev/mapper/backup-data',
     }}
 
     it { should contain_lvm__volume('data').with(
@@ -19,7 +19,7 @@ describe 'performanceplatform::backup_box', :type => :class do
     )}
 
     it { should contain_performanceplatform__mount('/mnt/data/backup').with(
-        :disk   => '/dev/mapper/data-backup',
+        :disk   => '/dev/mapper/backup-data'
     )}
 
     it { should contain_file('/mnt/data/backup/postgresql').with(


### PR DESCRIPTION
We misunderstood the way our LVM volumes derive their name in
/dev/mapper which has been causing provisioning failures - see 
https://deploy.preview.performance.service.gov.uk/job/puppet-deploy/449/console

This should fix them.
