### PR TITLE
Add requirement for sensu checks

### DIFF
--- a/modules/performanceplatform/manifests/checks/backups.pp
+++ b/modules/performanceplatform/manifests/checks/backups.pp
@@ -3,6 +3,7 @@ class performanceplatform::checks::backups (
     $freshness_script ="/etc/sensu/check-directory-freshness.sh"
 
     file { $freshness_script:
+      ensure  => present,
       require => Class['sensu'],
       owner   => 'root',
       group   => 'root',
@@ -14,11 +15,13 @@ class performanceplatform::checks::backups (
       interval => 3600,
       command  => "${freshness_script} /mnt/data/backups/postgresql",
       handlers => ['default'],
+      require  => File[$freshness_script],
     }
 
     sensu::check { 'mongo_backups_copy_check':
       interval => 3600,
       command  => "${freshness_script} /mnt/data/backups/mongodb",
       handlers => ['default'],
+      require  => File[$freshness_script],
     }
 }


### PR DESCRIPTION
The mongo and postgresql sensu checks use a script, but they didn't require
it so it wasn't present.

Related to https://github.com/alphagov/pp-puppet/pull/327

See https://www.pivotaltracker.com/story/show/66160874 [#66160874]
