### PR TITLE
Remove circular dependency

### DIFF
--- a/modules/performanceplatform/manifests/checks/backups.pp
+++ b/modules/performanceplatform/manifests/checks/backups.pp
@@ -4,7 +4,6 @@ class performanceplatform::checks::backups (
 
     file { $freshness_script:
       ensure  => present,
-      require => Class['sensu'],
       owner   => 'root',
       group   => 'root',
       mode    => '0777',


### PR DESCRIPTION
The sensu::check classes should already depend on the sensu class, so we 
shouldn't need to to require it explicitly (and certainly not from that 
script file)
