### PR TITLE
Fix backdrop smoke test

### DIFF
--- a/modules/performanceplatform/files/backdrop-write-read-test.rb
+++ b/modules/performanceplatform/files/backdrop-write-read-test.rb
@@ -36,7 +36,7 @@ class BackdropWriteReadTest< Sensu::Plugin::Check::CLI
       begin
         read_api_response = JSON.parse(read.body)
         read_api_timestamp = read_api_response['data'][0]['_timestamp']
-      rescue JSONError, IndexError
+      rescue JSON::JSONError, IndexError
         critical "Failed to parse JSON from read API"
       end
 

--- a/modules/performanceplatform/files/backdrop-write-read-test.rb
+++ b/modules/performanceplatform/files/backdrop-write-read-test.rb
@@ -36,8 +36,8 @@ class BackdropWriteReadTest< Sensu::Plugin::Check::CLI
       begin
         read_api_response = JSON.parse(read.body)
         read_api_timestamp = read_api_response['data'][0]['_timestamp']
-      rescue JSON::JSONError, IndexError
-        critical "Failed to parse JSON from read API"
+      rescue JSON::JSONError, IndexError => e
+        critical "Failed to parse JSON from read API: #{e.message} - #{read.body}"
       end
 
       begin


### PR DESCRIPTION
This smoke test was failing with an initialised constant error rather
than reporting a JSON error.

Add the error message and read response to JSON parse failures in the
backdrop smoke test.

In Kibana all the requests are claiming to be fine so this is very
strange. I'd like a bit more detail on it.
