### PR TITLE
Use full production Stagecraft domain

### DIFF
--- a/manifests/nodes.pp
+++ b/manifests/nodes.pp
@@ -12,7 +12,7 @@ $public_domain_name  = hiera('public_domain_name', $domain_name)
 $www_vhost           = join(['www',$public_domain_name],'.')
 $admin_vhost         = join(['admin',$public_domain_name],'.')
 $assets_vhost        = join(['assets',$public_domain_name],'.')
-$stagecraft_vhost    = join(['stagecraft',$public_domain_name],'.')
+$stagecraft_vhost    = join(['stagecraft',$domain_name],'.')
 # Private vhosts
 $assets_internal_vhost = 'assets.frontend'
 $deploy_vhost        = join(['deploy',$domain_name],'.')


### PR DESCRIPTION
Use stagecraft.production.performance.service.gov.uk rather than
stagecraft.performance.service.gov.uk as it's only available to GDS
at the moment.

Mutual dependency with: https://github.gds/gds/pp-deployment/pull/188
