### PR TITLE
Fix /mnt/data/backup directory (idiot)

### DIFF
--- a/modules/performanceplatform/manifests/checks/backups.pp
+++ b/modules/performanceplatform/manifests/checks/backups.pp
@@ -12,14 +12,14 @@ class performanceplatform::checks::backups (
 
     sensu::check { 'postgresql_backups_copy_check':
       interval => 3600,
-      command  => "${freshness_script} /mnt/data/backups/postgresql",
+      command  => "${freshness_script} /mnt/data/backup/postgresql",
       handlers => ['default'],
       require  => File[$freshness_script],
     }
 
     sensu::check { 'mongo_backups_copy_check':
       interval => 3600,
-      command  => "${freshness_script} /mnt/data/backups/mongodb",
+      command  => "${freshness_script} /mnt/data/backup/mongodb",
       handlers => ['default'],
       require  => File[$freshness_script],
     }


### PR DESCRIPTION
It's `/mnt/data/backup/*' not '/mnt/data/backups/'

Related to https://github.com/alphagov/pp-puppet/pull/327
