### PR TITLE
Improve alert behaviour on backup age

### DIFF
--- a/modules/performanceplatform/files/check-directory-freshness.sh
+++ b/modules/performanceplatform/files/check-directory-freshness.sh
@@ -7,7 +7,7 @@ if [ ! -d "${CHECK_DIRECTORY}" ]; then
     exit 1
 fi
 
-files_found=$(find "${CHECK_DIRECTORY}" -ctime -1 -type f ! -empty)
+files_found=$(find "${CHECK_DIRECTORY}" -mtime -1.125 -type f ! -empty)
 
 if [ "${files_found}" = "" ]; then
     echo "No new files found in ${CHECK_DIRECTORY}"


### PR DESCRIPTION
- Use mtime instead of ctime, this gives the date the backup was
  modified on the _source_ box rather than when it was copied onto the
  backups box.
- Allow 1/8th of a day tolerance to allow for the time between the
  backup being created and it being copied over.
