### PR TITLE
Improve backdrop smoke test

### DIFF
--- a/modules/performanceplatform/files/backdrop-write-read-test.rb
+++ b/modules/performanceplatform/files/backdrop-write-read-test.rb
@@ -27,30 +27,41 @@ class BackdropWriteReadTest< Sensu::Plugin::Check::CLI
     auth = config[:auth_token]
 
     begin
-      write = write_to_backdrop(backdrop_url, auth, payload)
-
-      if !write.body.to_s.include?("ok")
-        critical "Failed to write to the write API: #{write.body}"
-      end
-
-      sleep(SLEEP_CONST)
-
-      read = read_from_backdrop(backdrop_url, start_time) 
 
       begin
-        read_api_response = JSON.parse(read.body)
-        read_api_timestamp = read_api_response['data'][0]['_timestamp']
+        write_response = write_to_backdrop(backdrop_url, auth, payload)
+
+        if write_response.response_code != 200
+          critical "Received bad status code from write API: #{write_response.response_code}"
+        end
+
+        write_response_body = JSON.parse(write_response.body)
+        if write_response_body['status'] != 'ok'
+          critical "Received invalid response from write API: #{write_response.body}"
+        end
+      rescue JSON::JSONError, IndexError => e
+        critical "Failed to parse JSON from write API: #{e.message}, #{write_response.body}"
+      end
+
+      # Allow time for the record to be propagated to mongo cluster
+      sleep(SLEEP_CONST)
+
+      read_response = read_from_backdrop(backdrop_url, start_time) 
+
+      begin
+        read_response_body = JSON.parse(read_response.body)
+        timestamp = read_response_body['data'][0]['_timestamp']
       rescue JSON::JSONError, IndexError => e
         critical "Failed to parse JSON from read API: #{e.message} - #{read.body}"
       end
 
       begin
-        read_api_timestamp = Time.parse(read_api_timestamp).utc
+        timestamp = Time.parse(timestamp).utc
       rescue TimeError
-        critical "Failed to parse time from read API '#{read_api_timestamp}'"
+        critical "Failed to parse time from read API '#{timestamp}'"
       end
 
-      critical "Failed to read latest record from the read API" if (start_time - read_api_timestamp) >= API_TIME_TO_WRITE
+      critical "Failed to read latest record from the read API" if (start_time - timestamp) >= API_TIME_TO_WRITE
 
       ok "Succeeded in writing and reading from backdrop"
     rescue StandardError => e
@@ -60,7 +71,7 @@ class BackdropWriteReadTest< Sensu::Plugin::Check::CLI
 
  private
 
-  def writing_to_backdrop(backdrop_url, bearer_token, payload)
+  def write_to_backdrop(backdrop_url, bearer_token, payload)
     Curl::Easy.http_post(URI.parse(backdrop_url).to_s, payload.to_json) do |curl|
       curl.headers['Content-Type'] = 'application/json'
       curl.headers['Authorization'] = "Bearer #{bearer_token}"
@@ -72,7 +83,7 @@ class BackdropWriteReadTest< Sensu::Plugin::Check::CLI
     end_time = start_time + API_TIME_TO_WRITE
     uri_sorting_and_results_limitation = backdrop_url + "?sort_by=_timestamp:descending&limit=1&start_at=#{start_time.iso8601()}&end_at=#{end_time.iso8601()}"
 
-    return Curl::Easy.http_get(uri_sorting_and_results_limitation) do |curlinfo|
+    Curl::Easy.http_get(uri_sorting_and_results_limitation) do |curlinfo|
       curlinfo.ssl_verify_peer = false
     end
   end

--- a/modules/performanceplatform/files/backdrop-write-read-test.rb
+++ b/modules/performanceplatform/files/backdrop-write-read-test.rb
@@ -64,7 +64,6 @@ class BackdropWriteReadTest< Sensu::Plugin::Check::CLI
     Curl::Easy.http_post(URI.parse(backdrop_url).to_s, payload.to_json) do |curl|
       curl.headers['Content-Type'] = 'application/json'
       curl.headers['Authorization'] = "Bearer #{bearer_token}"
-      curl.headers['Content-Type'] = "application/json"
       curl.ssl_verify_peer = false
     end
   end


### PR DESCRIPTION
When the backdrop smoke test fails to write to the write API add the
response to the Sensu error message. This is to help debug some intermittent failures we're getting.
