### PR TITLE
Add environment specific domain names

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -195,11 +195,13 @@ performanceplatform::dns::hosts: |
 
 performanceplatform::dns::cnames:
   - [ "%{::admin_vhost}", "frontend" ]
+  - [ "%{::admin_env_vhost}", "frontend" ]
   - [ "%{::assets_vhost}", "frontend" ]
   - [ "%{::assets_internal_vhost}", "frontend" ]
   - [ "%{::spotlight_vhost}", "frontend" ]
   - [ "%{::stagecraft_vhost}", "frontend" ]
   - [ "%{::www_vhost}", "frontend" ]
+  - [ "%{::www_env_vhost}", "frontend" ]
 
 performanceplatform::mongo::mongo_hosts:
   - mongo-1

--- a/manifests/nodes.pp
+++ b/manifests/nodes.pp
@@ -10,7 +10,9 @@ $domain_name         = hiera('domain_name')
 $public_domain_name  = hiera('public_domain_name', $domain_name)
 # Public vhosts
 $www_vhost           = join(['www',$public_domain_name],'.')
+$www_env_vhost       = join(['www',$domain_name],'.')
 $admin_vhost         = join(['admin',$public_domain_name],'.')
+$admin_env_vhost     = join(['admin',$domain_name],'.')
 $assets_vhost        = join(['assets',$public_domain_name],'.')
 $stagecraft_vhost    = join(['stagecraft',$domain_name],'.')
 # Private vhosts


### PR DESCRIPTION
[fixes 68792636]
https://www.pivotaltracker.com/story/show/68792636

For admin and assets add environment specific domain names as cnames to
dnsmasq.

In production we serve www (for example) on
www.performance.service.gov.uk and on
www.production.performance.service.gov.uk. If one of these URLs is not
set up on dnsmasq it will resolve to our external IP address which isn't
accessible from within our infrastructure.
