### PR TITLE
Require lsof debian package

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -226,6 +226,7 @@ system_packages:
   - git
   - htop
   - libcurl4-gnutls-dev
+  - lsof
   - lvm2
   - parted
   - ssl-cert


### PR DESCRIPTION
Useful for spotting files that are being held open by processes. That
has happened on monitoring where a process has held open a log file that
was supposedly rotated.
