### PR TITLE
Get mongo log into kibana

### DIFF
--- a/hieradata/role-mongo.yaml
+++ b/hieradata/role-mongo.yaml
@@ -7,3 +7,9 @@ ufw_rules:
   allowmongo:
     port: 27017
     ip:   'any'
+
+lumberjack_instances:
+  mongo:
+    log_files: [ '/var/log/mongodb/mongodb.log' ]
+    fields:
+      tags: [ 'mongo' ]


### PR DESCRIPTION
Mongo outputs a log file. It's not JSON, but it would be very helpful to get
it into Kibana to diagnose problems on the system.

Each line should end up in the @message field and the @tags should be set to
['mongo'].

See https://github.com/alphagov/puppet-lumberjack/blob/963590c087433819e396db96eafab7f8eb2f101f/manifests/logshipper.pp
