### PR TITLE
Add logrotate rule for mongodb log

### DIFF
--- a/modules/performanceplatform/manifests/mongo.pp
+++ b/modules/performanceplatform/manifests/mongo.pp
@@ -8,6 +8,21 @@ class performanceplatform::mongo (
         logpath      => '/var/log/mongodb/mongodb.log',
         dbpath       => '/var/lib/mongodb'
     }
+    logrotate::rule { "mongodb-rotate":
+      path          => "/var/log/mongodb/mongodb.log",
+      rotate        => 30,
+      rotate_every  => 'day',
+      missingok     => true,
+      compress      => true,
+      create        => true,
+      sharedscripts => true,
+      create_mode   => '0640',
+      create_group  => 'mongodb',
+      create_user   => 'mongodb',
+      # This is ugly, mongodb does it's own logrotation so we need to remove them
+      # http://viktorpetersson.com/2011/12/22/mongodb-and-logrotate/
+      postrotate    => 'killall -SIGUSR1 mongod && find /var/log/mongodb/ -type f -regex ".*\.\(log.[0-9].*-[0-9].*\)" -exec rm {} \;'
+    }
     file { '/etc/mongodb':
         ensure  => 'directory',
         owner   => 'root',


### PR DESCRIPTION
The mongo log was not being rotated. This has a rather convoluted
postrotate step because mongodb tries to do it's own log rotation.
