### PR TITLE
Install cmake on development box

### DIFF
--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -90,6 +90,7 @@ vhost_proxies:
     upstream_port: 7999
 
 system_packages:
+  - cmake
   - libcairo2-dev
   - libjpeg8-dev
   - libpango1.0-dev


### PR DESCRIPTION
Similar to the jumpbox, we need it for cheapseats to `npm install` successfully.
