### PR TITLE
Add test-box to internal DNS

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -199,6 +199,7 @@ performanceplatform::dns::hosts: |
   172.27.1.52 logs-elasticsearch-2 elasticsearch
   172.27.1.61 postgresql-primary-1 postgresql-primary
   172.27.1.71 backup-box-1
+  172.27.1.80 test-box-1 test-box
 
 performanceplatform::dns::cnames:
   - [ "%{::admin_vhost}", "frontend" ]


### PR DESCRIPTION
We need this to test deploying Puppet to a new machine provisioned by
[#67821476]. We can't use an existing machine because it would require
destroying it and any disks/data.

/cc @roc 
