### PR TITLE
Include curl in common classes

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -127,6 +127,7 @@ classes:
   - 'collectd'
   - 'collectd::plugin::processes'
   - 'collectd::plugin::write_graphite'
+  - 'curl'
   - 'gcc'
   - 'harden'
   - 'lumberjack'


### PR DESCRIPTION
curl was removed from the bootstrap in gds/pp-pilotis@734e4e1 and the
dependency for deployments removed in gds/pp-deployment@43f77f8.

However it's still useful to have curl installed on all machines for
debugging purposes. So include it here.
