### PR TITLE
Reduce stagecraft gunicorn timeout to 2s

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -35,6 +35,7 @@ gunicorn_apps:
     user:            'deploy'
     group:           'deploy'
     is_django:       true
+    timeout:         2
 
 backdrop_collectors:
   backdrop-ga-collector:


### PR DESCRIPTION
Stagecraft is an upstream app to backdrop and will ultimately be one for
other apps. It needs to be fast.
