### PR TITLE
Change bundler config path for vagrant provision

### DIFF
--- a/tools/bootstrap-vagrant
+++ b/tools/bootstrap-vagrant
@@ -52,7 +52,7 @@ check_bundler() {
 bundle_gems() {
   echo "--> Bundle gems" | pp
   cd /vagrant
-  bundle --path vendor/bundle \
+  BUNDLE_APP_CONFIG=vendor/bundle bundle --path vendor/bundle \
          --deployment \
          --standalone \
          --binstubs \


### PR DESCRIPTION
So that you're still able to run the tests on your host machine. We don't
stricly need the config to run Puppet because the paths get baked into the
binstubs.

After running `vagrant up` or `vagrant provision` a `.bundle/config` file is
written which prevents prevents the tests from being run on your host
machine.

```
➜  pp-puppet git:(master) cat .bundle/config

---
BUNDLE_DISABLE_SHARED_GEMS: '1'
➜  pp-puppet git:(master) vagrant provision jumpbox-1
…
➜  pp-puppet git:(master) cat .bundle/config

---
BUNDLE_DISABLE_SHARED_GEMS: '1'
BUNDLE_FROZEN: '1'
BUNDLE_PATH: vendor/bundle
BUNDLE_BIN: bin
BUNDLE_WITHOUT: build
➜  pp-puppet git:(master) bundle show
Gems included by the bundle:
  * bundler (1.5.1)
  * facter (1.7.5)
  * hiera (1.2.1)
  * json_pure (1.8.0)
  * puppet (3.4.3)
```

This means that, at best, some of the dependencies are missing and you get a
fairly helpful error message:

```
➜  pp-puppet git:(master) bundle exec rake
rake aborted!
cannot load such file -- puppet-lint

(See full trace by running task with --trace)
```

Or at worst you get this obscure error message because the Ruby version used
within your VM differs from the one on the host:

```
➜  pp-puppet git:(master) bundle exec rake
env: ruby1.9.1: No such file or directory
```
