### PR TITLE
Increase varnish min threads per pool

### DIFF
--- a/modules/varnish/templates/defaults.erb
+++ b/modules/varnish/templates/defaults.erb
@@ -37,7 +37,7 @@ VARNISH_ADMIN_LISTEN_ADDRESS=127.0.0.1
 VARNISH_ADMIN_LISTEN_PORT=6082
 
 # # The minimum number of worker threads to start
-VARNISH_MIN_THREADS=1
+VARNISH_MIN_THREADS=10
 
 # # The Maximum number of worker threads to start
 VARNISH_MAX_THREADS=1000


### PR DESCRIPTION
There are some strange pauses happening where varnish spends a lot of
time allocating a worker to a request. We have a hypothesis that this is
related to us setting the minimum number of workers per pool so low
however we haven't been able to show this reliably.

In the relevant logs section below you can see the Stagecraft requests taking
17 seconds to be assigned to a worker and the Backdrop requests waiting 17
seconds for their backends.

Useful links:
https://www.varnish-cache.org/trac/wiki/Varnishlog#ReqEnd
https://www.varnish-software.com/static/book/Tuning.html

Relevant logs:

```
   21 RxRequest    c GET
   21 RxURL        c /data-sets/carers_allowance_realtime
   21 ReqEnd       c 1109083890 1396902320.962973595 1396902320.963099718 17.573831320 0.000059366 0.000066757
   22 RxRequest    c GET
   22 RxURL        c /data-sets/sorn_realtime
   22 ReqEnd       c 1109083891 1396902320.963138819 1396902320.963191271 17.501542091 0.000022173 0.000030279
   24 RxRequest    c POST
   24 RxURL        c /carers_allowance_realtime
   24 ReqEnd       c 1109083885 1396902303.355446815 1396902320.971302748 0.000023842 17.615786791 0.000069141
   27 RxRequest    c POST
   27 RxURL        c /sorn_realtime
   27 ReqEnd       c 1109083887 1396902303.388607025 1396902320.971331358 0.028859615 17.582490206 0.000234127
```
