### PR TITLE
[#69179750] Upgrade collectd to 5.4

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -171,6 +171,7 @@ collectd::plugin::write_graphite::storerates: true
 collectd::purge: true
 collectd::purge_config: true
 collectd::recurse: true
+collectd::version: '5.4'
 
 basic_auth_username: username
 basic_auth_password: password


### PR DESCRIPTION
Upgrade from 5.3 to 5.4. The main reason for this upgrade is that the
collectd puppet module we use will only collect varnish stats with
collectd >= 5.4.

Change log:
https://collectd.org/wiki/index.php/Version_5.4

https://www.pivotaltracker.com/story/show/69179750
