### PR TITLE
Update Node.js from 0.10.21 to 0.10.26

### DIFF
--- a/modules/performanceplatform/manifests/nodejs.pp
+++ b/modules/performanceplatform/manifests/nodejs.pp
@@ -1,6 +1,6 @@
 class performanceplatform::nodejs {
   package { 'nodejs':
-    ensure  => "0.10.21-1chl1~${::lsbdistcodename}1",
+    ensure  => "0.10.26-1chl1~${::lsbdistcodename}1",
     require => [Apt::Ppa['ppa:gds/performance-platform'], Exec['apt-get-update']],
   }
   package { 'grunt-cli':


### PR DESCRIPTION
I have copied the package to the relevant PPA and it is "waiting to build": https://launchpad.net/~gds/+archive/performance-platform
