### PR TITLE
Add required packages for screenshot-as-a-service

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -42,6 +42,9 @@ system_packages:
     - libxml2-dev
     - libxslt1-dev
     - libffi-dev
+    - libcairo2-dev
+    - libjpeg-dev
+    - libgif-dev
 
 ufw_rules:
     allowhttpfromall:


### PR DESCRIPTION
During deployment we need to `npm install canvas`, which requires these packages be installed.
