### PR TITLE
Collect varnish stats

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -4,7 +4,6 @@ mod 'attachmentgenie/ssh',        '1.2.2'
 mod 'attachmentgenie/ufw',        '1.2.0'
 mod 'dwerder/graphite',           '3.0.1'
 mod 'gdsoperations/openconnect'
-mod 'pdxcat/collectd',            '1.1.0'
 mod 'puppetlabs/apt',             '1.4.0'
 mod 'puppetlabs/gcc',             '0.0.3'
 mod 'puppetlabs/nodejs',          '0.4.0'
@@ -24,6 +23,8 @@ mod 'archive',       :git => 'https://github.com/gini/puppet-archive.git',
                      :ref => '50d3370006f955ee9d5187623cc660670d01c58d'
 mod 'clamav',        :git => 'git://github.com/alphagov/puppet-clamav.git',
                      :ref => '31af4f0c2753dd25bca3dd0c7cc69d273c4d640d'
+mod 'collectd',      :git => 'git://github.com/alphagov/puppet-collectd.git',
+                     :ref => '6bb76aa27c8ae7bf7669921498d2b8aaf692df59'
 mod 'curl',          :git => 'git://github.com/alphagov/puppet-curl.git',
                      :ref => 'f4c6d175bdc6cbd71f71fbaa2544ef8f70c4ce48'
 mod 'elasticsearch', :git => 'git://github.com/gds-operations/puppet-elasticsearch.git',

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -21,8 +21,6 @@ FORGE
       example42/monitor (>= 2.0.0)
       example42/puppi (>= 2.0.0)
       ripienaar/concat (>= 0.2.0)
-    pdxcat/collectd (1.1.0)
-      puppetlabs/stdlib (>= 3.0.0)
     puppetlabs/apt (1.4.0)
       puppetlabs/stdlib (>= 2.2.1)
     puppetlabs/concat (1.0.0)
@@ -59,6 +57,14 @@ GIT
   sha: 31af4f0c2753dd25bca3dd0c7cc69d273c4d640d
   specs:
     clamav (0.0.1)
+      puppetlabs/stdlib (>= 3.0.0)
+
+GIT
+  remote: git://github.com/alphagov/puppet-collectd.git
+  ref: 6bb76aa27c8ae7bf7669921498d2b8aaf692df59
+  sha: 6bb76aa27c8ae7bf7669921498d2b8aaf692df59
+  specs:
+    collectd (1.1.0)
       puppetlabs/stdlib (>= 3.0.0)
 
 GIT
@@ -209,6 +215,7 @@ DEPENDENCIES
   attachmentgenie/ssh (= 1.2.2)
   attachmentgenie/ufw (= 1.2.0)
   clamav (>= 0)
+  collectd (>= 0)
   curl (>= 0)
   dwerder/graphite (= 3.0.1)
   elasticsearch (>= 0)
@@ -224,7 +231,6 @@ DEPENDENCIES
   mongodb (>= 0)
   netmanagers/fail2ban (= 1.1.0)
   nginx (>= 0)
-  pdxcat/collectd (= 1.1.0)
   puppetlabs/apt (= 1.4.0)
   puppetlabs/gcc (= 0.0.3)
   puppetlabs/nodejs (= 0.4.0)

--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -1,5 +1,6 @@
 ---
 classes:
+  - 'collectd::plugin::varnish'
   - 'nginx::server'
   - 'performanceplatform::assets'
   - 'phantomjs'


### PR DESCRIPTION
Upgrade collectd module. pdxcat/collectd haven't released a new version with updates to the
varnish plugin that we need so we have forked it into alphagov.

Add Varnish collectd plugin and collect;
CollectCache
CollectBackend
CollectConnections
CollectSHM
CollectFetch
CollectTotals
CollectWorkers
CollectCache
