### PR TITLE
Omit home_dir from account hieradata

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ User accounts are managed in 'hieradata/common.yaml'. They look like this:
 ```
 accounts:
     ssharpe:
-        home_dir: /home/ssharpe
         comment: Sam J Sharpe
         ssh_key: AAAAB3NzaC1yc2EAAAABIwAAAQEAyNoMftFLf3w0NOW7J0KUwOx9897CU352n3zKD3p/GCcdH4eMv1QI0BhjItZplWG8TzFSBfWOOSruRh1Gksa1l1jiQcisEio6Wr7kZ7bpvMMA45ZoaDc26HTB+r0BZkNn7Lwwxxvy+1pbqStnnKzb9OTYIyVkb495LS0x1EL/P9S/NWtpm8ZULa1JDplYMA5SqMZnhmlGAXdh8UnjdcdOgOm2ngA+geJBSzVbABECiIAklHU1PRzOtrq8SuO8JmXW6NkuL0aabdTgE6noIm+Nn7T5ufZpOpIGYimVI8+mu+efcBzAp5Q0vTRgSBLfggdczZbFfPXpIt1Ib+LEf+Cuqw==
         groups:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,7 +1,6 @@
 ---
 accounts:
   alexmuller:
-    home_dir: /home/alexmuller
     comment: Alex Muller
     ssh_keys:
       alexmuller:
@@ -9,7 +8,6 @@ accounts:
     groups:
       - gds
   anna:
-    home_dir: /home/anna
     comment: Anna Powell-Smith
     ssh_keys:
       anna:
@@ -17,11 +15,9 @@ accounts:
     groups:
       - gds
   bt:
-    home_dir: /home/bt
     comment: Brett Thomas - ITHC
     ensure: absent
   bthomas:
-    home_dir: /home/bthomas
     ensure: absent
   dcarley:
     comment: Dan Carley
@@ -34,7 +30,6 @@ accounts:
     groups:
       - gds
   jabley:
-    home_dir: /home/jabley
     comment: James Abley
     ssh_keys:
       jabley:
@@ -42,7 +37,6 @@ accounts:
     groups:
       - gds
   jacobashdown:
-    home_dir: /home/jacobashdown
     comment: Jacob Ashdown
     ssh_keys:
       jacobashdown:
@@ -52,7 +46,6 @@ accounts:
     groups:
       - gds
   nickg:
-    home_dir: /home/nickg
     comment: Nick Gravgaard
     ssh_keys:
       nickg:
@@ -60,7 +53,6 @@ accounts:
     groups:
       - gds
   paulfurley:
-    home_dir: /home/paulfurley
     comment: Paul Furley
     ssh_keys:
       paulfurley-xps-2013-12-18:
@@ -69,9 +61,7 @@ accounts:
       - gds
   pauloschneider:
     ensure: absent
-    home_dir: /home/pauloschneider
   robyoung:
-    home_dir: /home/robyoung
     comment: Rob Young
     ssh_keys:
       robyoung:
@@ -81,7 +71,6 @@ accounts:
     groups:
       - gds
   roc:
-    home_dir: /home/roc
     comment: Ralph Cowling
     ssh_keys:
       roc:
@@ -89,7 +78,6 @@ accounts:
     groups:
       - gds
   ssharpe:
-    home_dir: /home/ssharpe
     comment: Sam J Sharpe
     ssh_keys:
       ssharpe:
@@ -97,7 +85,6 @@ accounts:
     groups:
       - gds
   tombooth:
-    home_dir: /home/tombooth
     comment: Tom Booth
     ssh_keys:
       tombooth:
@@ -107,10 +94,8 @@ accounts:
     groups:
       - gds
   gkoth:
-    home_dir: /home/gkoth
     ensure: absent
   urmy:
-    home_dir: /home/urmy
     comment: Urmy Urmston
     ssh_keys:
       urmy:


### PR DESCRIPTION
These aren't required. The `account` module will default to
`/home/${username}` if nothing is provided, which matches the current
values:

https://github.com/alphagov/puppet-account/blob/bcd1a5f3600478a4f914137e935185a498f59a79/manifests/init.pp#L107-108

By not providing these we reduce the risk of typos and differences between
accounts.
