### PR TITLE
Fix the upgrade of Kibana

### DIFF
--- a/modules/performanceplatform/manifests/kibana.pp
+++ b/modules/performanceplatform/manifests/kibana.pp
@@ -12,7 +12,7 @@ class performanceplatform::kibana(
   $tarball_name = regsubst($tarball_url, $name_regex, '\1')
   $app_root = "${extract_location}/${tarball_name}"
 
-  archive { 'kibana':
+  archive { 'kibana3.0.1':
     ensure   => present,
     url      => $tarball_url,
     target   => $extract_location,

--- a/modules/performanceplatform/manifests/kibana.pp
+++ b/modules/performanceplatform/manifests/kibana.pp
@@ -19,6 +19,13 @@ class performanceplatform::kibana(
     checksum => false,
   }
 
+  file { "${extract_location}/kibana-3.0.0milestone4":
+    ensure  => absent,
+    purge   => true,
+    recurse => true,
+    backup  => false,
+  }
+
   file { "${app_root}/config.js":
     ensure  => present,
     content => template('performanceplatform/kibana.config.js.erb'),


### PR DESCRIPTION
Earlier commit a44090a did not work on preview. This was due to the fact
that the archive resource had the same name so puppet skipped over
downloading the new tarball. Giving the archive resource a name that
includes the version forces a new download to take place.

Remove old Kibana version.
