### PR TITLE
Force remove the old Kibana directory

### DIFF
--- a/modules/performanceplatform/manifests/kibana.pp
+++ b/modules/performanceplatform/manifests/kibana.pp
@@ -21,6 +21,7 @@ class performanceplatform::kibana(
 
   file { "${extract_location}/kibana-3.0.0milestone4":
     ensure  => absent,
+    force   => true,
     purge   => true,
     recurse => true,
     backup  => false,


### PR DESCRIPTION
The previous attempt at this in d0937af57 didn't successfully remove the
directory.
