### PR TITLE
Revert Kibana upgrade

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -30,7 +30,7 @@ performanceplatform::jenkins::plugin_hash:
         version: "1.12"
 
 performanceplatform::kibana::elasticsearch_url: "https://%{::elasticsearch_vhost}"
-performanceplatform::kibana::tarball_url: 'https://download.elasticsearch.org/kibana/kibana/kibana-3.0.1.tar.gz'
+performanceplatform::kibana::tarball_url: 'https://download.elasticsearch.org/kibana/kibana/kibana-3.0.0milestone4.tar.gz'
 
 
 python::version:    '2.7'

--- a/modules/performanceplatform/manifests/kibana.pp
+++ b/modules/performanceplatform/manifests/kibana.pp
@@ -12,14 +12,14 @@ class performanceplatform::kibana(
   $tarball_name = regsubst($tarball_url, $name_regex, '\1')
   $app_root = "${extract_location}/${tarball_name}"
 
-  archive { 'kibana3.0.1':
+  archive { 'kibana3.0.0milestone4':
     ensure   => present,
     url      => $tarball_url,
     target   => $extract_location,
     checksum => false,
   }
 
-  file { "${extract_location}/kibana-3.0.0milestone4":
+  file { "${extract_location}/kibana-3.0.1":
     ensure  => absent,
     purge   => true,
     recurse => true,
@@ -29,7 +29,7 @@ class performanceplatform::kibana(
   file { "${app_root}/config.js":
     ensure  => present,
     content => template('performanceplatform/kibana.config.js.erb'),
-    require => Archive['kibana3.0.1'],
+    require => Archive['kibana3.0.0milestone4'],
   }
 
   nginx::vhost { 'kibana-vhost':
@@ -39,7 +39,7 @@ class performanceplatform::kibana(
     access_logs => {
       '{name}.access.log.json' => 'json_event',
     },
-    require     => Archive['kibana3.0.1'],
+    require     => Archive['kibana3.0.0milestone4'],
   }
 
 }


### PR DESCRIPTION
Kibana 3.0.1 depends on elasticsearch 0.90.0. We are currently on
0.20.6. Upgrading elasticsearch would be quite a bit of work for no
discernable gain and there are no new features in Kibana that we
absolutely need so I'm rolling this back.
