### PR TITLE
[#69625846] Adding server checks to postgres and backups

### DIFF
--- a/hieradata/role-monitoring.yaml
+++ b/hieradata/role-monitoring.yaml
@@ -12,6 +12,7 @@ classes:
 performanceplatform::checks::servers::boxes:
   - backend-app-1
   - backend-app-2
+  - backup-box-1
   - frontend-app-1
   - frontend-app-2
   - jumpbox-1
@@ -21,6 +22,7 @@ performanceplatform::checks::servers::boxes:
   - monitoring-1
   - logs-elasticsearch-1
   - logs-elasticsearch-2
+  - postgresql-primary-1
 
 collectd::plugin::processes::process_matches:
   - name: 'logstash'


### PR DESCRIPTION
- Fortunately these checks should largely be token additions, as we already have criticals around `stagecraft_access_data_sets_health_check` on the backend app boxes, and a `keepalive` check hanging around.
- These should inform us something is wrong, but it's good to know that the box being down is the root cause.
- Now if only I could figure out how to remotely restart the box :-/
