### PR TITLE
Add foreman to development machine

### DIFF
--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -100,6 +100,7 @@ system_packages:
 
 ruby_packages:
   - bowler
+  - foreman
 
 python_packages:
   - virtualenvwrapper


### PR DESCRIPTION
It's a runtime depedency of bowler already, but we should specify it.

Is there a way to pin these to specific versions? It would be useful to resolve alphagov/pp-development#48.
