### PR TITLE
Rename perfplat.dev to full dev domain

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,8 +84,8 @@ end
 
 Vagrant.configure("2") do |config|
   if Vagrant.has_plugin? "vagrant-dns"
-    config.dns.tld = "perfplat.dev"
-    config.dns.patterns = [/^.*perfplat.dev$/]
+    config.dns.tld = "development.performance.service.gov.uk"
+    config.dns.patterns = [/^.*development.performance.service.gov.uk$/]
   end
 
   hosts.each do |host|

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -237,4 +237,5 @@ ruby_packages:
 python_packages:
   - gds-nagios-plugins
 
+nginx::server::server_names_hash_bucket_size: 128
 nginx::server::version: '1.4.4-4~precise0'

--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -96,8 +96,6 @@ vhost_proxies:
     denied_http_verbs:
       - PURGE
 
-nginx::server::server_names_hash_bucket_size: 128
-
 nginx_conf:
   logging:
     template: performanceplatform/nginx.logging.conf.erb

--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -8,8 +8,6 @@ classes:
     - 'google_credentials'
     - 'phantomjs'
 
-nginx::server::server_names_hash_bucket_size: 128
-
 performanceplatform::jenkins::lts: 1
 performanceplatform::jenkins::plugin_hash:
     git-client:


### PR DESCRIPTION
Maintaining 2 domain names in development is a pain, so we're just going to use the full one.
