### PR TITLE
Add jenkins as host alias to jumpbox-1

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -175,7 +175,7 @@ nameservers:
   - 8.8.4.4
 
 performanceplatform::dns::hosts: |
-  172.27.1.2  jumpbox-1
+  172.27.1.2  jumpbox-1 jenkins
   172.27.1.11 frontend-app-1 frontend
   172.27.1.12 frontend-app-2 frontend
   172.27.1.21 backend-app-1 backend


### PR DESCRIPTION
So that scripts (ie sensu alerts) can access Jenkins to eg download build
artifacts.

Related to https://www.pivotaltracker.com/story/show/67409248

[#67409248]
