### PR TITLE
Make sure git is installed before using it

### DIFF
--- a/modules/performanceplatform/manifests/base.pp
+++ b/modules/performanceplatform/manifests/base.pp
@@ -65,6 +65,7 @@ class performanceplatform::base {
         provider => git,
         source   => 'https://github.com/alphagov/sensu-community-plugins.git',
         revision => '86baac527cee804e6c0e795edf1d77bd85e5b355',
+        require  => Package['git'],
     }
 
 }


### PR DESCRIPTION
I saw an issue when trying to bring the development vm up were git
hadn't been installed before we tried to use it to checkout the
community plugins.
