### PR TITLE
Reduce the high CPU check warning limit

### DIFF
--- a/modules/performanceplatform/manifests/checks/server.pp
+++ b/modules/performanceplatform/manifests/checks/server.pp
@@ -6,7 +6,7 @@ define performanceplatform::checks::server (
 
     performanceplatform::checks::graphite { "check_high_cpu_${name}":
       target   => "movingAverage(collectd.${graphite_fqdn}.cpu-0.cpu-idle,120)",
-      warning  => '20:',
+      warning  => '10:',
       critical => '5:',
       interval => 60,
       handlers => ['default'],


### PR DESCRIPTION
Was 20% idle over 2 minutes, reduce to 10% idle over 2 minutes.
A server running relatively warm is not something we need to be warned
about.

I considered reducing this to 5% and reducing the critical even further.
