### PR TITLE
Test on 1.9.3 and 2.1.1 & be less wimpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
   - 1.9.3
-  - 2.0.0
   - 2.1.1
 before_install:
   - gem install puppet
@@ -11,10 +10,6 @@ script:
   - ./run_tests.sh
 notifications:
   email: false
-matrix:
-  allow_failures:
-    - rvm: 2.0.0
-    - rvm: 2.1.1
 branches:
   except:
     - /^build_\d+$/


### PR DESCRIPTION
Our actual "supported" ruby version is 1.9.3 so we should definitely be 
testing on that.

It seems excessive to test on an additional _two_ future ruby versions. Just 
test on 2.1.1 and don't be wimpy about allowing failures. It's currently 
passing so let's prep ourselves for a future upversion.

Also three versions can't help our (dreadful) Travis build times...
