### PR TITLE
Development machine in vcl

### DIFF
--- a/modules/varnish/templates/default.vcl.development.erb
+++ b/modules/varnish/templates/default.vcl.development.erb
@@ -2,13 +2,12 @@
 # you're not sure what that is, see here:
 #
 #   https://www.varnish-cache.org/trac/browser/bin/varnishd/default.vcl?rev=3.0
+import std;
 
 acl purge_acl {
   "localhost";
   "development-1";
 }
-
-
 
 # Defining the backends per-director so we can have separate healthchecks later
 backend admin_backend {
@@ -87,13 +86,16 @@ sub vcl_recv {
   # origin.
   set req.grace = 6h;
 
-  # purge individual URLs from the cache
+  # purge URLs from the cache
   if (req.request == "PURGE") {
     if (!client.ip ~ purge_acl) {
-      error 405 "Not allowed";
+      std.log("client ip not in purge_acl: " +client.ip);
+      error 403 "Forbidden";
     } else {
-      ban("req.url == " + req.url);
-      error 200 "Purged";
+      # Wildcard purging
+      ban("req.url ~ "+req.url);
+      std.log("purging: " +req.url);
+      error 200 "Purged.";
     }
   }
 

--- a/modules/varnish/templates/default.vcl.development.erb
+++ b/modules/varnish/templates/default.vcl.development.erb
@@ -5,6 +5,7 @@
 
 acl purge_acl {
   "localhost";
+  "development-1";
 }
 
 


### PR DESCRIPTION
- Requests coming in on development-1 vm come through as `10.0.0.100` which is referenced as follows in `/etc/hosts`:

`10.0.0.100  development-1.internal  development-1`
- This change adds the name of the machine as we reference it in the Vagrantfile, which I thought seemed the most correct way of doing this.
- Alternatively we could add a `localhost` alias on 10.0.0.100 in `/etc/hosts`

---
- Wildcard purging wasn't in the development vcl.
- This should be cleaned up and consolidated by whoever picks up [#70928834](https://www.pivotaltracker.com/story/show/70928834)
- For now I'm just trying to make the dev and default vcl files work in as close a manner as possible.
