### PR TITLE
Add collectd load average plugin

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -117,6 +117,7 @@ classes:
   - 'apt'
   - 'apt::unattended_upgrades'
   - 'collectd'
+  - 'collectd::plugin::load'
   - 'collectd::plugin::processes'
   - 'collectd::plugin::write_graphite'
   - 'curl'


### PR DESCRIPTION
This is off the back of a discussion with @paulfurley regarding the CPU checks being really noisy and not very useful. Once this is in, I'm going to see if using the load average would be a bit more useful.
