### PR TITLE
Make postrotate send a USR1 rather than upstart

### DIFF
--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -82,7 +82,7 @@ define performanceplatform::proxy_vhost(
     create_mode  => '0640',
     create_owner => $::user,
     create_group => $::group,
-    postrotate   => 'service nginx rotate',
+    postrotate   => '[ ! -f /var/run/nginx.pid ] || kill -USR1 `cat /var/run/nginx.pid`',
   }
 
   nginx::vhost::proxy { $name:


### PR DESCRIPTION
The nginx version that we use in development, staging and production (1.4.4) doesn't support doing a rotate by upstart, which is different from the version that we're using in preview (1.5.11).

I authored this in March. No idea why I didn't send a pull request for it. Our JSON log rotation is broken in staging and production.
