### PR TITLE
Do not check Authorization header in varnish

### DIFF
--- a/modules/varnish/templates/default.vcl.development.erb
+++ b/modules/varnish/templates/default.vcl.development.erb
@@ -45,13 +45,9 @@ sub vcl_recv {
     set req.backend   = stagecraft_backend;
   } else if (req.http.Host ~ "^www\..*") {
     # Send www requests to backdrop
-    if (req.request == "POST") {
-      if (req.http.Authorization ~ "^Bearer .*") {
-        set req.http.Host = "write.backdrop";
-        set req.backend   = write_backend;
-      } else {
-        error 671 "Bearer token not set";
-      }
+    if (req.request ~ "^(PUT|POST|DELETE)$") {
+      set req.http.Host = "write.backdrop";
+      set req.backend   = write_backend;
     } else if (req.request ~ "^(GET|HEAD|OPTIONS)$") {
       set req.http.Host = "read.backdrop";
       set req.backend   = read_backend;
@@ -173,10 +169,6 @@ sub vcl_error {
   if (obj.status == 667) {
     set obj.http.Location = obj.response;
     set obj.status = 301;
-    return(deliver);
-  } elsif (obj.status == 671) { #671 is our internal, needs a Bearer token
-    set obj.http.WWW-Authenticate = "Bearer";
-    set obj.status = 401;
     return(deliver);
   }
 }

--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -144,12 +144,8 @@ sub vcl_recv {
   } else if (req.http.Host ~ "^www\..*") {
     # Send www requests to backdrop
     if (req.request ~ "^(PUT|POST|DELETE)$") {
-      if (req.http.Authorization ~ "^Bearer .*") {
-        set req.http.Host = "write.backdrop";
-        set req.backend   = write_director;
-      } else {
-        error 671 "Bearer token not set";
-      }
+      set req.http.Host = "write.backdrop";
+      set req.backend   = write_director;
     } else if (req.request ~ "^(GET|HEAD|OPTIONS)$") {
       set req.http.Host = "read.backdrop";
       set req.backend   = read_director;
@@ -270,10 +266,6 @@ sub vcl_error {
   if (obj.status == 667) {
     set obj.http.Location = obj.response;
     set obj.status = 301;
-    return(deliver);
-  } elsif (obj.status == 671) { #671 is our internal, needs a Bearer token
-    set obj.http.WWW-Authenticate = "Bearer";
-    set obj.status = 401;
     return(deliver);
   }
 }


### PR DESCRIPTION
This is checked in backdrop and backdrop returns a helpfull error
message.

Also, less logic in varnish FTW!
