### PR TITLE
Missed providing a location for the two asset dirs

### DIFF
--- a/modules/performanceplatform/manifests/assets.pp
+++ b/modules/performanceplatform/manifests/assets.pp
@@ -21,6 +21,7 @@ class performanceplatform::assets (
   }
 
   nginx::resource::location { 'spotlight-assets':
+    location            => '/spotlight/',
     rewrite_rules       => [
       '^/spotlight(.*)$ $1 break'
     ],
@@ -32,6 +33,7 @@ class performanceplatform::assets (
   }
 
   nginx::resource::location { 'stagecraft-assets':
+    location            => '/stagecraft/',
     rewrite_rules       => [
       '^/stagecraft(.*)$ $1 break'
     ],


### PR DESCRIPTION
The resource will fallback to using the name, which is less than ideal.
This explicitly sets them to the correct value.
