### PR TITLE
Create opbeat proxy location

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -4,6 +4,7 @@ classes:
   - 'nginx'
   - 'performanceplatform::assets'
   - 'performanceplatform::nginx_logging_formats'
+  - 'performanceplatform::opbeat_proxy'
   - 'phantomjs'
   - 'screenshot_as_a_service::app'
   - 'spotlight::app'
@@ -91,6 +92,11 @@ vhost_proxies:
     pp_only_vhost: true
     denied_http_verbs:
       - PURGE
+
+performanceplatform::opbeat_proxy::servername: "%{::www_vhost}"
+performanceplatform::opbeat_proxy::organisation_id: 'foo'
+performanceplatform::opbeat_proxy::app_id: 'foo'
+performanceplatform::opbeat_proxy::token: 'foo'
 
 lumberjack_instances:
   nginx:

--- a/modules/performanceplatform/manifests/opbeat_proxy.pp
+++ b/modules/performanceplatform/manifests/opbeat_proxy.pp
@@ -1,0 +1,21 @@
+class performanceplatform::opbeat_proxy(
+  $servername,
+  $organisation_id,
+  $app_id,
+  $token,
+  $endpoint = '/exception',
+  $ssl      = true,
+) {
+
+  nginx::resource::location { "${servername}-opbeat-proxy":
+    vhost    => $servername,
+    location => $endpoint,
+    ssl      => $ssl,
+    proxy    => "https://opbeat.com/api/v1/organizations/${organisation_id}/apps/${app_id}/errors/",
+    location_cfg_append => {
+      proxy_set_header => "Authorization \"Bearer ${token}\"",
+    },
+  }
+
+
+}


### PR DESCRIPTION
We want to proxy through to the opbeat exception capturing endpoint so
that we can keep our token secret.

All of the secrets are waiting for merging in pp-deployment.
