### PR TITLE
Add X-Forwarded-Proto header in Nginx proxy

### DIFF
--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -121,6 +121,9 @@ define performanceplatform::proxy_vhost(
   } else {
     $forward_host = []
   }
+  $forwarded_proto = [
+    'X-Forwarded-Proto  $scheme',
+  ]
 
   if $denied_http_verbs and !empty($denied_http_verbs) {
     $vhost_cfg_append = {
@@ -140,7 +143,7 @@ define performanceplatform::proxy_vhost(
     ssl_key                     => "${ssl_path}/${ssl_key}",
     rewrite_to_https            => $ssl_redirect,
     client_max_body_size        => $client_max_body_size,
-    proxy_set_header            => flatten([$forwarded_host, $forward_host]),
+    proxy_set_header            => flatten([$forwarded_host, $forward_host, $forwarded_proto]),
     access_log                  => "/var/log/nginx/${servername}.access.log.json json_event",
     error_log                   => "/var/log/nginx/${servername}.error.log",
     auth_basic                  => $auth_basic,


### PR DESCRIPTION
Add the X-Forwarded-Proto header to vhosts proxied by Nginx. This is
used by Stagecraft to determine whether it should redirect to
HTTP/HTTPS.
