### PR TITLE
Only set the X-Forwarded-Proto for SSL vhosts

### DIFF
--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -121,9 +121,14 @@ define performanceplatform::proxy_vhost(
   } else {
     $forward_host = []
   }
-  $forwarded_proto = [
-    'X-Forwarded-Proto  $scheme',
-  ]
+
+  if $ssl {
+    $forwarded_proto = [
+      'X-Forwarded-Proto  $scheme',
+    ]
+  } else {
+    $forwarded_proto = []
+  }
 
   if $denied_http_verbs and !empty($denied_http_verbs) {
     $vhost_cfg_append = {


### PR DESCRIPTION
Only set the X-Forwarded-Proto header on the SSL terminating (ie. public
facing) vhost. If we set it again on the backend app vhost we clobber
the header coming from the SSL terminating vhost.
