### PR TITLE
Add a dummy command to sensu::check

### DIFF
--- a/modules/performanceplatform/manifests/backdrop_smoke_tests.pp
+++ b/modules/performanceplatform/manifests/backdrop_smoke_tests.pp
@@ -7,6 +7,7 @@ class performanceplatform::backdrop_smoke_tests (
     }
 
     sensu::check { 'backdrop_smoke_tests':
+      command  => "dummy",
       ensure => absent,
     }
 }


### PR DESCRIPTION
It is required, even if you're ensuring absent.
