### PR TITLE
Notify the sensu client when removing smoke test

### DIFF
--- a/modules/performanceplatform/manifests/backdrop_smoke_tests.pp
+++ b/modules/performanceplatform/manifests/backdrop_smoke_tests.pp
@@ -7,7 +7,8 @@ class performanceplatform::backdrop_smoke_tests (
     }
 
     sensu::check { 'backdrop_smoke_tests':
-      command  => "dummy",
-      ensure => absent,
+      command => "dummy",
+      ensure  => absent,
+      notify  => Service['sensu-client'],
     }
 }


### PR DESCRIPTION
sensu::check doesn't notify the sensu client service so it doesn't get
restarted and then you bash your head against a wall for quite a long
time.
