### PR TITLE
Listen on full graphite domain in upstream

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -74,7 +74,7 @@ vhost_proxies:
         ssl:             true
         ssl_redirect:    true
         upstream_server: 'graphite'
-        upstream_port:   9080
+        upstream_port:   80
         forward_host_header: false
         four_warning:  ':3'
         four_critical: ':5'

--- a/hieradata/role-monitoring.yaml
+++ b/hieradata/role-monitoring.yaml
@@ -76,7 +76,7 @@ ufw_rules:
 
 vhost_proxies:
   graphite-vhost:
-    servername:      "graphite"
+    servername:      "%{::graphite_vhost}"
     ssl:             false
     upstream_server: 'localhost'
     upstream_port:   9080


### PR DESCRIPTION
The nginx proxy vhost on jumpbox doesn't modify the host header so
the vhost on monitoring should just listen on the same host name.
