### PR TITLE
Use full graphite hostname for checks

### DIFF
--- a/modules/performanceplatform/manifests/checks/graphite.pp
+++ b/modules/performanceplatform/manifests/checks/graphite.pp
@@ -9,7 +9,7 @@ define performanceplatform::checks::graphite (
 ) {
 
   $check_data_path = '/etc/sensu/community-plugins/plugins/graphite/check-data.rb'
-  $server_config = "-s graphite -u ${::basic_auth_username} -p ${::basic_auth_password}"
+  $server_config = "-s ${::graphite_vhost} -u ${::basic_auth_username} -p ${::basic_auth_password}"
 
   if $ignore_no_data {
     $ignore_no_data_flag = '--ignore-no-data'


### PR DESCRIPTION
This is what it's server over.

This is to stop the flood of alerts on preview. I'm going to look into setting the upstream hostname instead.
