### PR TITLE
Fix graphite

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -70,11 +70,12 @@ vhost_proxies:
         four_warning:  ':3'
         four_critical: ':5'
     graphite-vhost:
-        servername:      "%{::graphite_vhost}"
-        ssl:             true
-        ssl_redirect:    true
-        upstream_server: 'graphite'
-        upstream_port:   80
+        servername:        "%{::graphite_vhost}"
+        ssl:               true
+        ssl_redirect:      true
+        upstream_server:   'graphite'
+        upstream_hostname: 'graphite'
+        upstream_port:     80
         forward_host_header: false
         four_warning:  ':3'
         four_critical: ':5'

--- a/hieradata/role-monitoring.yaml
+++ b/hieradata/role-monitoring.yaml
@@ -76,7 +76,7 @@ ufw_rules:
 
 vhost_proxies:
   graphite-vhost:
-    servername:      "%{::graphite_vhost}"
+    servername:      "graphite"
     ssl:             false
     upstream_server: 'localhost'
     upstream_port:   9080

--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -3,6 +3,7 @@ define performanceplatform::proxy_vhost(
   $priority            = '10',
   $template            = 'nginx/vhost-proxy.conf.erb',
   $upstream_server     = 'localhost',
+  $upstream_hostname   = undef,
   $upstream_port       = '8080',
   $servername          = '',
   $serveraliases       = undef,
@@ -114,7 +115,11 @@ define performanceplatform::proxy_vhost(
     ]
   }
 
-  if $forward_host_header {
+  if $upstream_hostname {
+    $forward_host = [
+      "Host ${upstream_hostname}",
+    ]
+  } elsif $forward_host_header {
     $forward_host = [
       'Host $host',
     ]


### PR DESCRIPTION
Add $upstream_hostname to proxy_vhost define. Nginx uses the name of the upstream as the proxy hostname unless you explicitly tell it otherwise. We do this by forwarding the incoming hostname for all vhosts except graphite. This parameter allows us to explicitly set the upstream hostname for the graphite vhost.
