### PR TITLE
Fix expires directive for new nginx module

### DIFF
--- a/modules/performanceplatform/manifests/assets.pp
+++ b/modules/performanceplatform/manifests/assets.pp
@@ -21,27 +21,27 @@ class performanceplatform::assets (
   }
 
   nginx::resource::location { 'spotlight-assets':
-    location            => '/spotlight/',
-    rewrite_rules       => [
+    location             => '/spotlight/',
+    rewrite_rules        => [
       '^/spotlight(.*)$ $1 break'
     ],
-    vhost               => $::assets_internal_vhost,
-    www_root            => '/opt/spotlight/current/public',
-    location_custom_cfg => {
+    vhost                => $::assets_internal_vhost,
+    www_root             => '/opt/spotlight/current/public',
+    location_cfg_prepend => {
       'expires' => '30d',
-    }
+    },
   }
 
   nginx::resource::location { 'stagecraft-assets':
-    location            => '/stagecraft/',
-    rewrite_rules       => [
+    location             => '/stagecraft/',
+    rewrite_rules        => [
       '^/stagecraft(.*)$ $1 break'
     ],
-    vhost               => $::assets_internal_vhost,
-    www_root            => '/opt/stagecraft/current/assets',
-    location_custom_cfg => {
+    vhost                => $::assets_internal_vhost,
+    www_root             => '/opt/stagecraft/current/assets',
+    location_cfg_prepend => {
       'expires' => '1h',
-    }
+    },
   }
 
 }


### PR DESCRIPTION
This was changed in ac5714d827bc782e78125ebe01efc6aeec42bcde when we started to use the new module, but the docs for the module we're now using say:

```
location_custom_cfg - cannot be used with other location types (proxy, fastcgi, root, or stub_status)
```

Changing to location_cfg_prepend ensures that the expires directive is present in the location block.

This will change the header from `Cache-Control: max-age=900` (default, set by Varnish) to 2592000 (Spotlight) or 3600 (Stagecraft).

You'll probably want the [non-whitespace version of this diff](https://github.com/alphagov/pp-puppet/pull/421/files?w=1).
