### PR TITLE
Add performanceplatform-collector to hieradata

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -59,6 +59,9 @@ backdrop_collectors:
   backdrop-pingdom-collector:
     user: 'deploy'
     group: 'deploy'
+  performanceplatform-collector:
+    user: 'deploy'
+    group: 'deploy'
 
 python::version:    '2.7'
 python::dev:        true


### PR DESCRIPTION
So that puppet creates directories ready for the deployment job.

See https://www.pivotaltracker.com/story/show/7114765

[Delivers #71147654]
