### PR TITLE
Set request_time to double in elasticsearch config

### DIFF
--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -60,9 +60,8 @@ class performanceplatform::elasticsearch(
               "path": "full",
               "dynamic": true,
               "properties": {
-                "args": {
-                    "type": "string"
-                }
+                "args": {"type": "string"},
+                "request_time": {"type": "double"}
               },
               "type": "object"
             },


### PR DESCRIPTION
Set the request_time field to be of type double in the elasticsearch
mapping for logstash.

In some indexes it is being interpreted as a string which breaks some
Kibana queries that expect it to be a number.
