### PR TITLE
Use IP addresses for dev in the Varnish ACL

### DIFF
--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -6,7 +6,7 @@ import std;
 
 acl purge_acl {
   "localhost";
-  "development-1";
+  "10.0.0.100";
   "172.27.1.0"/24; # weird but correct syntax: "ip"/netmask
 }
 


### PR DESCRIPTION
The development-1 hostname is not on production like environments.
