### PR TITLE
Increase the client_request size to 50m

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -39,7 +39,7 @@ gunicorn_apps:
     user:                 'deploy'
     group:                'deploy'
     statsd_prefix:        'backdrop.write'
-    client_max_body_size: '30m'
+    client_max_body_size: '50m'
     timeout:              60
   stagecraft:
     port:            3204


### PR DESCRIPTION
We are hitting the maximum request size of 30m when running imports on the
site-activity dashboard for top content. At some point we will need to look at
making the client request size smaller - this is a temporary fix so we can
collect data now.
