### PR TITLE
Add dev dependencies for building python lxml

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -8,6 +8,7 @@ classes:
   - 'performanceplatform::backdrop_smoke_tests'
   - 'performanceplatform::nginx_logging_formats'
   - 'performanceplatform::pip'
+  - 'performanceplatform::python_lxml_deps'
   - 'python'
   - 'postgresql::lib::devel'
 

--- a/modules/performanceplatform/manifests/python_lxml_deps.pp
+++ b/modules/performanceplatform/manifests/python_lxml_deps.pp
@@ -1,0 +1,14 @@
+class performanceplatform::python_lxml_deps() {
+
+  package { 'python-dev':
+    ensure  => installed,
+  }
+
+  package { 'libxml2-dev':
+    ensure  => installed,
+  }
+
+  package { 'libxstlt1-dev':
+    ensure  => installed,
+  }
+}


### PR DESCRIPTION
When you try and `pip install lxml` it builds the source package. This 
requires 3 dev packages be installed on the system.

See http://stackoverflow.com/a/6504860

See https://www.pivotaltracker.com/story/show/72070958

[#72070958]
