### PR TITLE
Fix development-1 Varnish configuration

### DIFF
--- a/modules/varnish/templates/backends.development.vcl.erb
+++ b/modules/varnish/templates/backends.development.vcl.erb
@@ -10,3 +10,18 @@ backend read_backend {
 backend stagecraft_backend {
     .host = "backend-app-1";
 }
+director admin_director round-robin {
+  { .backend = admin_backend; }
+}
+director frontend_app round-robin {
+  { .backend = admin_backend; }
+}
+director stagecraft_director round-robin {
+  { .backend = stagecraft_backend; }
+}
+director read_director round-robin {
+  { .backend = read_backend; }
+}
+director write_director round-robin {
+  { .backend = write_backend; }
+}


### PR DESCRIPTION
Varnish was failing with:

``` vagrant@dev-development-1:~$ sudo service varnish start
- Starting HTTP accelerator varnishd                                          
  
  ```
      [fail]  Message from VCC-compiler: Symbol not found:
  ```
  
  'frontend_app' (expected type BACKEND):
  ('input' Line 46 Pos 25)
  set req.backend   = frontend_app;
  ------------------------############-

Running VCC-compiler failed, exit 1

VCL compilation failed

```
```
