### PR TITLE
Fix typo in `libxslt1-dev` package name

### DIFF
--- a/modules/performanceplatform/manifests/python_lxml_deps.pp
+++ b/modules/performanceplatform/manifests/python_lxml_deps.pp
@@ -8,7 +8,7 @@ class performanceplatform::python_lxml_deps() {
     ensure  => installed,
   }
 
-  package { 'libxstlt1-dev':
+  package { 'libxslt1-dev':
     ensure  => installed,
   }
 }


### PR DESCRIPTION
https://deploy.preview.performance.service.gov.uk/job/puppet-deploy/567/console

Embarrassing, sorry!
