### PR TITLE
Install PhantomJS 1.9.7 from our PPA

### DIFF
--- a/modules/phantomjs/manifests/init.pp
+++ b/modules/phantomjs/manifests/init.pp
@@ -1,28 +1,12 @@
 class phantomjs {
 
-  include curl
-
-  curl::fetch { 'download phantomjs':
-    source      => 'https://gds-public-readable-tarballs.s3.amazonaws.com/phantomjs-1.9.1-linux-x86_64.tar.bz2',
-    destination => '/usr/local/src/phantomjs-1.9.1-linux-x86_64.tar.bz2',
-    timeout     => 3600,
+  package { 'phantomjs':
+    ensure => '1.9.7-0~ppa1',
   }
 
-  exec { 'unpack phantomjs':
-    require => Curl::Fetch['download phantomjs'],
-    creates => '/usr/local/src/phantomjs-1.9.1-linux-x86_64',
-    cwd     => '/usr/local/src',
-    command => '/bin/tar -jxf ./phantomjs-1.9.1-linux-x86_64.tar.bz2'
-  }
-
+  # FIXME: Remove when this has been run in all environments
   file { '/usr/local/bin/phantomjs':
-    ensure  => link,
-    target  => '/usr/local/src/phantomjs-1.9.1-linux-x86_64/bin/phantomjs',
-    require => Exec['unpack phantomjs'],
-  }
-
-  package { 'libfontconfig1':
-    ensure => present,
+    ensure  => absent,
   }
 
 }


### PR DESCRIPTION
This upgrades PhantomJS from 1.9.1 to 1.9.7, in line with CI.
- https://github.com/alphagov/ci-puppet/pull/172
- https://github.com/alphagov/ci-puppet/pull/173
