### PR TITLE
Allow jenkins from network

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -59,6 +59,9 @@ ufw_rules:
     allowsshfromanywhere:
         port: 22
         ip:   'any'
+    allowjenkinsfromnetwork:
+        port: 8080
+        ip:   172.27.1.0/24
 
 vhost_proxies:
     deploy-vhost:


### PR DESCRIPTION
This is required for the smokey tests scripts.

The Jenkins puppet module adds a firewall rule for 8080 from anywhere.
However, it seems this is not always applied on a reboot. I'm not sure
if this is an order issue but either way it should be explicitly
controlled by us.
