### PR TITLE
Add an assets directory for each app

### DIFF
--- a/modules/performanceplatform/manifests/app.pp
+++ b/modules/performanceplatform/manifests/app.pp
@@ -23,7 +23,7 @@ define performanceplatform::app (
   $log_path = "/var/log/${title}"
 
   file { [$app_path, "${app_path}/releases", "${app_path}/shared",
-          "${app_path}/shared/log", $config_path, $log_path]:
+          "${app_path}/shared/log", "${app_path}/shared/assets", $config_path, $log_path]:
     ensure  => directory,
     owner   => $user,
     group   => $group,


### PR DESCRIPTION
This directory is in shared, so it will remain across deployments.

My intention is to copy the application assets into this directory during each deployment (ideally as early as possible), and once that is done repoint the Spotlight assets vhost to use this new directory when serving assets.
