### PR TITLE
Change location of Spotlight assets on disk

### DIFF
--- a/modules/performanceplatform/manifests/assets.pp
+++ b/modules/performanceplatform/manifests/assets.pp
@@ -26,7 +26,7 @@ class performanceplatform::assets (
       '^/spotlight(.*)$ $1 break'
     ],
     vhost                => $::assets_internal_vhost,
-    www_root             => '/opt/spotlight/current/public',
+    www_root             => '/opt/spotlight/shared/assets',
     location_cfg_prepend => {
       'expires' => '30d',
     },


### PR DESCRIPTION
We now have a shared directory and the deployment process stores the app's assets in it on each deployment.

Change the place that the vhost looks for to serve up assets.

This will mean that we can continue to serve assets for old deployed versions of the app, so that we should have no cases where we 404 assets anymore.

Before merging this:
- [x] Merge #442
- [x] Deploy #442 to every environment
- [x] Merge pp-deployment#276
- [x] Manually create new assets directory contents in each environment
