### PR TITLE
Add .pypirc file to jenkins home dir

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -106,3 +106,8 @@ vhost_proxies:
 lumberjack_instances:
     nginx:
         log_files: [ '/var/log/nginx/*.access.log.json' ]
+
+performanceplatform::pypi::test_username: pp-developers
+performanceplatform::pypi::test_password: "test password"
+performanceplatform::pypi::live_username: pp-developers
+performanceplatform::pypi::live_password: "live password"

--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -4,6 +4,7 @@ classes:
     - 'performanceplatform::kibana'
     - 'performanceplatform::nodejs'
     - 'performanceplatform::nginx_logging_formats'
+    - 'performanceplatform::pypi'
     - 'python'
     - 'nginx'
     - 'google_credentials'

--- a/modules/performanceplatform/files/pp-dev-pypirc.erb
+++ b/modules/performanceplatform/files/pp-dev-pypirc.erb
@@ -1,0 +1,14 @@
+[distutils] # this tells distutils what package indexes you can push to
+index-servers =
+    pypi # the live PyPI
+    pypitest # test PyPI
+
+[pypi] # authentication details for live PyPI
+repository: https://pypi.python.org/pypi
+username: <%= $live_username %>
+password: <%= $live_password %>
+
+[pypitest] # authentication details for test PyPI
+repository: https://testpypi.python.org/pypi
+username: <%= $test_username %>
+password: <%= $test_password %>

--- a/modules/performanceplatform/manifests/jenkins.pp
+++ b/modules/performanceplatform/manifests/jenkins.pp
@@ -7,6 +7,7 @@ class performanceplatform::jenkins(
     lts         => $lts,
     plugin_hash => $plugin_hash,
   }
+  contain 'jenkins'
 
   package { 'keychain':
     ensure  => installed,

--- a/modules/performanceplatform/manifests/pypi.pp
+++ b/modules/performanceplatform/manifests/pypi.pp
@@ -1,0 +1,17 @@
+class performanceplatform::pypi (
+  $test_username="foo",
+  $test_password="foo",
+  $live_username="foo",
+  $live_password="foo",
+) {
+    $pipyirc_file = "/home/jenkins/.pipyirc"
+
+    file { $pipyirc_file:
+      ensure => present,
+      owner  => 'jenkins',
+      group  => 'jenkins',
+      mode   => '0644',
+      source => "puppet:///modules/performanceplatform/pp-dev-pypirc.erb"
+    }
+
+}

--- a/modules/performanceplatform/manifests/pypi.pp
+++ b/modules/performanceplatform/manifests/pypi.pp
@@ -1,17 +1,18 @@
 class performanceplatform::pypi (
-  $test_username="foo",
-  $test_password="foo",
-  $live_username="foo",
-  $live_password="foo",
+  $test_username,
+  $test_password,
+  $live_username,
+  $live_password,
 ) {
-    $pipyirc_file = "/home/jenkins/.pipyirc"
+    $pipyirc_file = "/var/lib/jenkins/.pipyirc"
 
     file { $pipyirc_file:
       ensure => present,
       owner  => 'jenkins',
       group  => 'jenkins',
       mode   => '0644',
-      source => "puppet:///modules/performanceplatform/pp-dev-pypirc.erb"
+      content => template('performanceplatform/pp-dev-pypirc.erb'),
+      require => Class['performanceplatform::jenkins']
     }
 
 }

--- a/modules/performanceplatform/templates/pp-dev-pypirc.erb
+++ b/modules/performanceplatform/templates/pp-dev-pypirc.erb
@@ -5,10 +5,10 @@ index-servers =
 
 [pypi] # authentication details for live PyPI
 repository: https://pypi.python.org/pypi
-username: <%= @live_username %>
-password: <%= @live_password %>
+username: <%= $live_username %>
+password: <%= $live_password %>
 
 [pypitest] # authentication details for test PyPI
 repository: https://testpypi.python.org/pypi
-username: <%= @test_username %>
-password: <%= @test_password %>
+username: <%= $test_username %>
+password: <%= $test_password %>


### PR DESCRIPTION
- Well, almost the jenkins home dir, actually to `/var/lib/jenkins/`
- Allows Jenkins user to publish to PyPI as detailed in https://www.pivotaltracker.com/story/show/71565298
