### PR TITLE
Remove pypi creds from jumpbox machine role

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -106,8 +106,3 @@ vhost_proxies:
 lumberjack_instances:
     nginx:
         log_files: [ '/var/log/nginx/*.access.log.json' ]
-
-performanceplatform::pypi::test_username: pp-developers
-performanceplatform::pypi::test_password: "test password"
-performanceplatform::pypi::live_username: pp-developers
-performanceplatform::pypi::live_password: "live password"


### PR DESCRIPTION
- Having them here was overriding the ones from pp-deployment, not the other way round.
