### PR TITLE
Remove comments from .pypirc file

### DIFF
--- a/modules/performanceplatform/templates/pp-dev-pypirc.erb
+++ b/modules/performanceplatform/templates/pp-dev-pypirc.erb
@@ -1,14 +1,14 @@
 [distutils] # this tells distutils what package indexes you can push to
 index-servers =
-    pypi # the live PyPI
-    pypitest # test PyPI
+    pypi
+    pypitest
 
-[pypi] # authentication details for live PyPI
+[pypi]
 repository: https://pypi.python.org/pypi
 username: <%= @live_username %>
 password: <%= @live_password %>
 
-[pypitest] # authentication details for test PyPI
+[pypitest]
 repository: https://testpypi.python.org/pypi
 username: <%= @test_username %>
 password: <%= @test_password %>


### PR DESCRIPTION
- distutils freaks and raises an exception if there are comments in the index-server lines:

`raise NoSectionError(section)
ConfigParser.NoSectionError: No section: 'pypi # the live PyPI'`

![](http://www.reactiongifs.com/wp-content/uploads/2013/06/disappointed.gif)
