### PR TITLE
Set an HSTS header to require SSL for 1 month

### DIFF
--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -131,10 +131,12 @@ define performanceplatform::proxy_vhost(
     $forwarded_proto = [
       'X-Forwarded-Proto  $scheme',
     ]
-    # nginx module does not add client_max_body_size to the ssl vhost
-    # workaround until pull request on module is accepted.
     $vhost_cfg_ssl_prepend = {
-      'client_max_body_size' => $client_max_body_size
+      # nginx module does not add client_max_body_size to the ssl vhost
+      # workaround until pull request on module is accepted.
+      'client_max_body_size' => $client_max_body_size,
+      # Set an HSTS header to enforce SSL for 1 month
+      'add_header' => 'Strict-Transport-Security "max-age=2628000"',
     }
   } else {
     $forwarded_proto = []


### PR DESCRIPTION
Currently we're not setting HSTS anywhere on our domains.

I'm hoping that this will avoid the annoying situation where by:

```
$ curl -v http://assets.performance.service.gov.uk/spotlight/stylesheets/spotlight.css
```

does not receive a response. Ideally we'll be able to increase this once we verify that it's working as expected. GOV.UK currently sets this to be 1 year.
