### PR TITLE
Re-enable legacy collectors

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -54,19 +54,19 @@ backdrop_collectors:
   backdrop-ga-collector:
     user: 'deploy'
     group: 'deploy'
-    ensure: 'absent'
+    ensure: 'present'
   backdrop-ga-realtime-collector:
     user: 'deploy'
     group: 'deploy'
-    ensure: 'absent'
+    ensure: 'present'
   backdrop-ga-trending-collector:
     user: 'deploy'
     group: 'deploy'
-    ensure: 'absent'
+    ensure: 'present'
   backdrop-pingdom-collector:
     user: 'deploy'
     group: 'deploy'
-    ensure: 'absent'
+    ensure: 'present'
   performanceplatform-collector:
     user: 'deploy'
     group: 'deploy'


### PR DESCRIPTION
The removal doesn't quite work yet and therefore prevents puppet going
out.
