### PR TITLE
Use default Graphite storage aggregation config

### DIFF
--- a/modules/performanceplatform/files/graphite/storage-aggregation.conf
+++ b/modules/performanceplatform/files/graphite/storage-aggregation.conf
@@ -1,0 +1,32 @@
+# Aggregation methods for whisper files. Entries are scanned in order,
+# and first match wins. This file is scanned for changes every 60 seconds
+#
+#  [name]
+#  pattern = <regex>
+#  xFilesFactor = <float between 0 and 1>
+#  aggregationMethod = <average|sum|last|max|min>
+#
+#  name: Arbitrary unique name for the rule
+#  pattern: Regex pattern to match against the metric name
+#  xFilesFactor: Ratio of valid data points required for aggregation to the next retention to occur
+#  aggregationMethod: function to apply to data points for aggregation
+#
+[min]
+pattern = \.min$
+xFilesFactor = 0.1
+aggregationMethod = min
+
+[max]
+pattern = \.max$
+xFilesFactor = 0.1
+aggregationMethod = max
+
+[sum]
+pattern = \.count$
+xFilesFactor = 0
+aggregationMethod = sum
+
+[default_average]
+pattern = .*
+xFilesFactor = 0.5
+aggregationMethod = average

--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -20,6 +20,13 @@ class performanceplatform::monitoring (
     postrotate    => '/etc/init.d/apache2 reload > /dev/null',
   }
 
+  file { '/opt/graphite/conf/storage-aggregation.conf':
+    mode    => '0644',
+    source  => 'puppet:///modules/performanceplatform/graphite/storage-aggregation.conf',
+    require => Anchor['graphite::install::end'],
+    notify  => Service['carbon-cache'],
+  }
+
   file { '/etc/nginx/htpasswd':
     ensure    => present,
     content   => "${::basic_auth_username}:${::basic_auth_password_hashed}",


### PR DESCRIPTION
This is required for the GA API usage metrics so that they can use a
sum aggregation rather than the default average.
