### PR TITLE
Remove legacy collector resources

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -51,22 +51,6 @@ gunicorn_apps:
     timeout:         2
 
 backdrop_collectors:
-  backdrop-ga-collector:
-    user: 'deploy'
-    group: 'deploy'
-    ensure: 'absent'
-  backdrop-ga-realtime-collector:
-    user: 'deploy'
-    group: 'deploy'
-    ensure: 'absent'
-  backdrop-ga-trending-collector:
-    user: 'deploy'
-    group: 'deploy'
-    ensure: 'absent'
-  backdrop-pingdom-collector:
-    user: 'deploy'
-    group: 'deploy'
-    ensure: 'absent'
   performanceplatform-collector:
     user: 'deploy'
     group: 'deploy'


### PR DESCRIPTION
Not that they've been removed having these resources causes puppet to
fail because it tries to get the status of a service that doesn't
exist.
