### PR TITLE
Add libxml2 and libxslt dev packages

### DIFF
--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -109,6 +109,8 @@ system_packages:
   - libjpeg8-dev
   - libpango1.0-dev
   - libgif-dev
+  - libxml2-dev
+  - libxslt-dev
   - nfs-common
   - portmap
 


### PR DESCRIPTION
These are needed to run `python setup.py install` for the performanceplatform-collector repository.
