### PR TITLE
Remove ensure paramater to fix puppet

### DIFF
--- a/modules/backdrop_collector/manifests/app.pp
+++ b/modules/backdrop_collector/manifests/app.pp
@@ -29,7 +29,6 @@ define backdrop_collector::app ($user, $group, $ensure) {
     }
 
     lumberjack::logshipper { "collector-logs-for-${title}":
-        ensure    => $ensure,
         log_files => [ "${app_path}/current/log/collector.log.json" ],
     }
 }


### PR DESCRIPTION
lumberjack::logshipper doesnt take the ensure paramater so this
fails the catalog compilation. Need to remove the files / module in
another way in a further commit.
