### PR TITLE
Remove libxml2-dev package from development

### DIFF
--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -109,7 +109,6 @@ system_packages:
   - libjpeg8-dev
   - libpango1.0-dev
   - libgif-dev
-  - libxml2-dev
   - libxslt-dev
   - nfs-common
   - portmap


### PR DESCRIPTION
Otherwise it fails when provisioning the VM:

```
Error: Duplicate declaration: Package[libxml2-dev] is already declared in
file /vagrant/modules/performanceplatform/manifests/python_lxml_deps.pp:9;
cannot redeclare at /vagrant/manifests/nodes.pp:49 on node
development-1.localdomain

```
