### PR TITLE
Fix mongod and logstash process checks

### DIFF
--- a/modules/performanceplatform/manifests/mongo.pp
+++ b/modules/performanceplatform/manifests/mongo.pp
@@ -72,7 +72,7 @@ rs.initiate(replicaSetConfig());
     $escaped_fqdn = regsubst($::fqdn, '\.', '_', 'G')
 
     sensu::check { "mongod_is_down_${escaped_fqdn}":
-      command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p mongod -W 1 -C 1 -w -1 -c -1',
+      command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p mongod -W 1 -C 1',
       interval => 60,
       handlers => ['default'],
     }

--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -165,7 +165,7 @@ class performanceplatform::monitoring (
   }
 
   sensu::check { 'logstash_is_down':
-    command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p logstash -C 1 -c -1 -w -1 -W 2',
+    command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p logstash -C 1 -W 2',
     interval => 60,
     handlers => ['default'],
   }


### PR DESCRIPTION
After switching sensu community plugins back to the upstream repo these
checks started failing. It looks like the lower bound options are no
longer necesarry.

see: c921850
