### PR TITLE
The http check is failing to verify the ssl cert

### DIFF
--- a/modules/performanceplatform/manifests/checks/ssl.pp
+++ b/modules/performanceplatform/manifests/checks/ssl.pp
@@ -1,10 +1,10 @@
 class performanceplatform::checks::ssl () {
-  $check_http_path = '/etc/sensu/community-plugins/plugins/http/check-http.rb'
+  $check_https_path = '/etc/sensu/community-plugins/plugins/ssl/check-ssl-cert.rb'
 
   $domain_name = hiera('domain_name')
 
   sensu::check { 'ssl_expiry_check':
-    command  => "${check_http_path} -u https://www.${domain_name} -e 30",
+    command  => "${check_https_path} -h ${domain_name} -p 443 -c 30 -w 40",
     interval => 120,
     handlers => ['default'],
   }


### PR DESCRIPTION
Rather than debug exactly why, we will switch to this plugin which is
able to check ssl cert expiry.
