### PR TITLE
Add clamav running sensu check

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -4,6 +4,7 @@ classes:
   - 'clamav'
   - 'google_credentials'
   - 'performanceplatform::checks::backdrop'
+  - 'performanceplatform::checks::clamav'
   - 'performanceplatform::checks::stagecraft'
   - 'performanceplatform::backdrop_smoke_tests'
   - 'performanceplatform::nginx_logging_formats'

--- a/modules/performanceplatform/manifests/checks/clamav.pp
+++ b/modules/performanceplatform/manifests/checks/clamav.pp
@@ -1,0 +1,10 @@
+class performanceplatform::checks::clamav (
+) {
+
+  sensu::check { 'clamav_is_down':
+    command  => '/etc/init.d/clamav-daemon status',
+    interval => 60,
+    handlers => ['default']
+  }
+
+}


### PR DESCRIPTION
Clamav was down on backend-box-1 on production, all uploads to the box were failing. Restarting it manually has been stable so far but we should really know if it goes down again.
