### PR TITLE
Add status check for admin app

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -3,6 +3,7 @@ classes:
   - 'collectd::plugin::varnish'
   - 'nginx'
   - 'performanceplatform::assets'
+  - 'performanceplatform::checks::admin'
   - 'performanceplatform::nginx_logging_formats'
   - 'performanceplatform::opbeat_proxy'
   - 'performanceplatform::pip'

--- a/modules/performanceplatform/manifests/checks/admin.pp
+++ b/modules/performanceplatform/manifests/checks/admin.pp
@@ -1,0 +1,9 @@
+class performanceplatform::checks::admin () {
+  $check_http_path = '/etc/sensu/community-plugins/plugins/http/check-http.rb'
+
+  sensu::check { 'admin_status_check':
+    command  => "${check_http_path} -u http://localhost:3070/_status",
+    interval => 120,
+    handlers => ['default'],
+  }
+}


### PR DESCRIPTION
The /_status endpoint should return 200 if everything is OK and fail
otherwise.
