### PR TITLE
Revert logstash sensu handler

### DIFF
--- a/modules/performanceplatform/files/sensu_logstash_handler.rb
+++ b/modules/performanceplatform/files/sensu_logstash_handler.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+#
+# Sensu Logstash Handler
+#
+# Heavily inspried (er, copied from) the GELF Handler writeen by
+# Joe Miller.
+#
+# Designed to take sensu events, transform them into logstah JSON events
+# and ship them to a redis server for logstash to index.  This also
+# generates a tag with either 'sensu-ALERT' or 'sensu-RECOVERY' so that
+# searching inside of logstash can be a little easier.
+#
+# Written by Zach Dunn -- @SillySophist or http://github.com/zadunn
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-handler'
+require 'redis'
+require 'json'
+require 'socket'
+require 'time'
+
+class LogstashHandler < Sensu::Handler
+
+  def event_name
+    @event['client']['name'] + '/' + @event['check']['name']
+  end
+
+  def action_to_string
+    @event['action'].eql?('resolve') ? "RESOLVE" : "ALERT"
+  end
+
+  def handle
+    redis = Redis.new(:host => settings['logstash']['server'], :port => settings['logstash']['port'])
+    time = Time.now.utc.iso8601
+    logstash_msg = {
+      :@source => ::Socket.gethostname,
+      :@type => settings['logstash']['type'],
+      :@tags => ["sensu-#{action_to_string}"],
+      :@message => @event['check']['output'],
+      :@fields => {
+        :host          => @event['client']['name'],
+        :timestamp     => @event['check']['issued'],
+        :address       => @event['client']['address'],
+        :check_name    => @event['check']['name'],
+        :command       => @event['check']['command'],
+        :status        => @event['check']['status'],
+        :flapping      => @event['check']['flapping'],
+        :occurrences   => @event['occurrences'],
+        :flapping      => @event['check']['flapping'],
+        :occurrences   => @event['occurrences'],
+        :action        => @event['action']
+      },
+      :@timestamp => time
+    }
+    redis.lpush(settings['logstash']['list'], logstash_msg.to_json)
+  end
+end

--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -186,14 +186,29 @@ class performanceplatform::monitoring (
     }
   }
 
+  $handler_dir = '/etc/sensu/handlers/'
+  $notification_dir = "${handler_dir}notification/"
+
+  file { $notification_dir:
+    ensure => directory
+  }
+
+  $handler_file = "${notification_dir}logstash.rb"
+  file { $handler_file:
+    ensure  => 'present',
+    source  => 'puppet:///modules/performanceplatform/sensu_logstash_handler.rb',
+    require => File[$notification_dir]
+  }
+
   sensu::handler { 'logstash':
-    command   => '/etc/sensu/community-plugins/handlers/notification/logstash.rb',
-    config    => {
+    command => '/etc/sensu/handlers/notification/logstash.rb',
+    config  => {
       type   => 'sensu',
       server => 'redis',
       port   => 6379,
       list   => 'sensu-checks',
-    }
+    },
+    require => File[$handler_file]
   }
 
 }


### PR DESCRIPTION
Sensu community plugins updated the logstash handler to use a message
only accepted by logstash 1.2, not 1.1 which we use. This is the
previous working version, which is vendored here rather than
forking sensu-community-plugins again.

See
https://github.com/sensu/sensu-community-plugins/commit/b2257d7e8a17696fb7d0f1451a7ce2fe5c14320f#diff-e6d2ad1f8e19a38c7f6e8c1e87d7961d
and
https://logstash.jira.com/browse/LOGSTASH-675
