### PR TITLE
All jumpbox vhosts need the environment cert

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -69,6 +69,8 @@ vhost_proxies:
         servername:      "%{::deploy_vhost}"
         ssl:             true
         ssl_redirect:    true
+        ssl_cert:        "%{hiera('environment_ssl_cert')}"
+        ssl_key:         "%{hiera('environment_ssl_key')}"
         upstream_server: 'localhost'
         upstream_port:   8080
         four_warning:  '3'
@@ -77,6 +79,8 @@ vhost_proxies:
         servername:        "%{::graphite_vhost}"
         ssl:               true
         ssl_redirect:      true
+        ssl_cert:          "%{hiera('environment_ssl_cert')}"
+        ssl_key:           "%{hiera('environment_ssl_key')}"
         upstream_server:   'graphite'
         upstream_hostname: 'graphite'
         upstream_port:     80
@@ -87,6 +91,8 @@ vhost_proxies:
         servername:      "%{::alerts_vhost}"
         ssl:             true
         ssl_redirect:    true
+        ssl_cert:        "%{hiera('environment_ssl_cert')}"
+        ssl_key:         "%{hiera('environment_ssl_key')}"
         upstream_server: 'alerts'
         upstream_port:   80
         four_warning:  '3'
@@ -95,6 +101,8 @@ vhost_proxies:
         servername:      "%{::elasticsearch_vhost}"
         ssl:             true
         ssl_redirect:    true
+        ssl_cert:        "%{hiera('environment_ssl_cert')}"
+        ssl_key:         "%{hiera('environment_ssl_key')}"
         upstream_server: 'elasticsearch'
         upstream_port:   9200
         four_warning:  '3'


### PR DESCRIPTION
All the vhosts on the jumbpox, for management services, use environment
specific domain names (_.<environment>.performance.service.gov.uk) and
never the public domain names (_.performance.service.gov.uk). This means
that we need to ensure they always have the environment cert.
