### PR TITLE
Add SSL params to performanceplatform::app

### DIFF
--- a/modules/performanceplatform/manifests/app.pp
+++ b/modules/performanceplatform/manifests/app.pp
@@ -16,6 +16,8 @@ define performanceplatform::app (
   $proxy_set_forwarded_host = false,
   $client_max_body_size = '10m',
   $statsd_prefix = $title,
+  $ssl_cert      = hiera('public_ssl_cert'),
+  $ssl_key       = hiera('public_ssl_key'),
 ) {
   include nginx
   include upstart
@@ -35,6 +37,8 @@ define performanceplatform::app (
     servername                  => $servername,
     serveraliases               => $serveraliases,
     ssl                         => $proxy_ssl,
+    ssl_cert                    => $ssl_cert,
+    ssl_key                     => $ssl_key,
     proxy_append_forwarded_host => $proxy_append_forwarded_host,
     proxy_set_forwarded_host    => $proxy_set_forwarded_host,
     client_max_body_size        => $client_max_body_size,

--- a/modules/spotlight/manifests/app.pp
+++ b/modules/spotlight/manifests/app.pp
@@ -16,6 +16,8 @@ class spotlight::app (
     group                       => $group,
     servername                  => $::spotlight_vhost,
     proxy_ssl                   => true,
+    ssl_cert                    => hiera('environment_ssl_cert'),
+    ssl_key                     => hiera('environment_ssl_key'),
     extra_env                   => {
       'NODE_ENV' => $::pp_environment,
     },


### PR DESCRIPTION
We need to be able to set the ssl_cert/key for spotlight::app through
performanceplatform::app. Spotlight's vhost is always on an environment
domain (*.<env>.performance.service.gov.uk) so it needs to use the
environment_cert/key. By default it should fall back to using the
default of the proxy_vhost, which is public_cert/key.
