### PR TITLE
Install libffi-dev on frontend-app machines

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -144,3 +144,4 @@ system_packages:
   - libjpeg8-dev
   - libpango1.0-dev
   - libgif-dev
+  - libffi-dev


### PR DESCRIPTION
To get around issues with SNI in python we are using pyOpenSSL to do
SSL, this requires a crypto library that uses libffi. My
performanceplatform-admin commit for reference:

https://github.com/alphagov/performanceplatform-admin/commit/56b8491fd27b19da38a8e062b0771e933ea2925d
