### PR TITLE
Change the app module for the admin app

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -30,7 +30,7 @@ spotlight::app::group:      'deploy'
 gunicorn_apps:
   performanceplatform-admin:
     port:          3070
-    app_module:    'admin.app:app'
+    app_module:    'admin:app'
     user:          'deploy'
     group:         'deploy'
     statsd_prefix: 'admin.app'


### PR DESCRIPTION
I've reorganised the admin app so that the app now boots in `admin/__init__.py`. Reflect that change here.
