### PR TITLE
Add envinject plugin to Jenkins

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -16,6 +16,8 @@ nginx::vhost_purge: true
 
 performanceplatform::jenkins::lts: 1
 performanceplatform::jenkins::plugin_hash:
+    envinject:
+        version: "1.88"
     git-client:
         version: "1.0.6"
     git:


### PR DESCRIPTION
In order for one click deploys to find the tag to release and push this
back to Jenkins to trigger a deploy we need to be able to inject
environment variables back into Jenkins.
