### PR TITLE
Add a logrotate rule for elasticsearch

### DIFF
--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -102,4 +102,14 @@ class performanceplatform::elasticsearch(
     handlers => ['default'],
   }
 
+  logrotate::rule { 'elasticsearch-rotate':
+    path         => '/var/log/elasticsearch/elasticsearch.log.*',
+    rotate       => 30,
+    rotate_every => 'day',
+    missingok    => true,
+    compress     => true,
+    create       => true,
+    create_mode  => '0640',
+  }
+
 }


### PR DESCRIPTION
compressing log files should help with disk space - and we dont need to
keep logs going back to 2013...
