### PR TITLE
Revert "Add a rule to allow redis from the jumpbox"

### DIFF
--- a/hieradata/role-monitoring.yaml
+++ b/hieradata/role-monitoring.yaml
@@ -84,9 +84,6 @@ ufw_rules:
   allowsyslogfromanywhere:
     port: 514
     ip:   'any'
-  allowredisfromjumpbox:
-    port: 6379
-    ip:   '172.27.1.2'
 
 vhost_proxies:
   graphite-vhost:


### PR DESCRIPTION
This reverts commit c10462641a8dac4a95d38b26526131167d3fea9c.

Turns out I was trying to start the api on jumpbox instead of
monitoring. Although in my defence there was an error message saying
"sensu-api dead but pidfile remaining"...
