### PR TITLE
Elasticsearch needs java before it will work

### DIFF
--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -12,7 +12,7 @@ class performanceplatform::elasticsearch(
     host                  => $::hostname,
     heap_size             => $heap_size,
     minimum_master_nodes  => $minimum_master_nodes,
-    require               => Performanceplatform::Mount[$data_dir],
+    require               => [Performanceplatform::Mount[$data_dir], Class['java7']]
   }
 
 


### PR DESCRIPTION
This worked before because the elasticsearch package specified java as a
dependency, but the package install now wont work without the puppet
class.
