### PR TITLE
Move requirement of libffi-dev into common

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -232,6 +232,7 @@ system_packages:
   - git
   - htop
   - libcurl4-gnutls-dev
+  - libffi-dev
   - lsof
   - lvm2
   - parted

--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -113,7 +113,6 @@ system_packages:
   - libjpeg8-dev
   - libpango1.0-dev
   - libgif-dev
-  - libffi-dev
   - libxslt-dev
   - nfs-common
   - portmap

--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -144,4 +144,3 @@ system_packages:
   - libjpeg8-dev
   - libpango1.0-dev
   - libgif-dev
-  - libffi-dev

--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -47,7 +47,6 @@ system_packages:
     - cmake
     - libxml2-dev
     - libxslt1-dev
-    - libffi-dev
     - libcairo2-dev
     - libjpeg-dev
     - libgif-dev


### PR DESCRIPTION
As development, frontend, backend and jumpbox now require libffi-dev
(for SNI in python2) I thourhg moving it into common would make sense.
