### PR TITLE
UFW rules which allow backend apps redis access

### DIFF
--- a/hieradata/role-monitoring.yaml
+++ b/hieradata/role-monitoring.yaml
@@ -84,6 +84,12 @@ ufw_rules:
   allowsyslogfromanywhere:
     port: 514
     ip:   'any'
+  allowredisfrombackend1:
+    port: 6379
+    ip:   '172.27.1.21'
+  allowredisfrombackend2:
+    port: 6379
+    ip:   '172.27.1.22'
 
 vhost_proxies:
   graphite-vhost:


### PR DESCRIPTION
Give access to both backend boxes. Moving forward we should think about
creating a separate backend network to make these changes easier - if we
ever spin up a new backend box it will almost certainly be forgotten to
add the firewall rule in here as well.
