### PR TITLE
Remove Varnish from in front of Stagecraft

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -3,6 +3,7 @@ classes:
   - 'backdrop_collector'
   - 'clamav'
   - 'google_credentials'
+  - 'nginx'
   - 'performanceplatform::checks::backdrop'
   - 'performanceplatform::checks::clamav'
   - 'performanceplatform::checks::stagecraft'
@@ -50,6 +51,21 @@ gunicorn_apps:
     group:           'deploy'
     is_django:       true
     timeout:         2
+
+vhost_proxies:
+  stagecraft-public-vhost:
+    servername:    "%{::stagecraft_vhost}"
+    ssl:           true
+    ssl_redirect:  true
+    ssl_cert:      "%{hiera('environment_ssl_cert')}"
+    ssl_key:       "%{hiera('environment_ssl_key')}"
+    upstream_server: localhost
+    upstream_port: 3204
+    four_warning: 1
+    four_critical: 3
+    five_warning: 0
+    five_critical: 1
+    pp_only_vhost: true
 
 backdrop_collectors:
   performanceplatform-collector:

--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -113,21 +113,6 @@ vhost_proxies:
     denied_http_verbs:
       - PURGE
 
-  stagecraft-vhost:
-    servername:    "%{::stagecraft_vhost}"
-    ssl:           true
-    ssl_redirect:  true
-    ssl_cert:      "%{hiera('environment_ssl_cert')}"
-    ssl_key:       "%{hiera('environment_ssl_key')}"
-    upstream_port: 7999
-    four_warning: 1
-    four_critical: 3
-    five_warning: 0
-    five_critical: 1
-    pp_only_vhost: true
-    denied_http_verbs:
-      - PURGE
-
 performanceplatform::opbeat_proxy::servername: "%{::www_vhost}"
 performanceplatform::opbeat_proxy::organisation_id: 'foo'
 performanceplatform::opbeat_proxy::app_id: 'foo'

--- a/modules/varnish/templates/backends.development.vcl.erb
+++ b/modules/varnish/templates/backends.development.vcl.erb
@@ -7,17 +7,11 @@ backend write_backend {
 backend read_backend {
     .host = "backend-app-1";
 }
-backend stagecraft_backend {
-    .host = "backend-app-1";
-}
 director admin_director round-robin {
   { .backend = admin_backend; }
 }
 director frontend_app round-robin {
   { .backend = admin_backend; }
-}
-director stagecraft_director round-robin {
-  { .backend = stagecraft_backend; }
 }
 director read_director round-robin {
   { .backend = read_backend; }

--- a/modules/varnish/templates/backends.vcl.erb
+++ b/modules/varnish/templates/backends.vcl.erb
@@ -23,14 +23,6 @@ backend read_backend_2 {
     .host = "backend-app-2";
     .probe = read_healthcheck;
 }
-backend stagecraft_backend_1 {
-    .host = "backend-app-1";
-    .probe = stagecraft_healthcheck;
-}
-backend stagecraft_backend_2 {
-    .host = "backend-app-2";
-    .probe = stagecraft_healthcheck;
-}
 
 backend frontend_app_1 {
   .host = "frontend-app-1";

--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -47,10 +47,6 @@ sub vcl_recv {
     set req.http.Host = "admin.backdrop";
     set req.backend   = admin_director;
     call redirect_slash;
-  } else if (req.http.Host ~ "^stagecraft\..*") {
-    # Send stagecraft requests to stagecraft
-    set req.http.Host = "stagecraft";
-    set req.backend = stagecraft_director;
   } else if (req.http.Host ~ "^www\..*") {
     # Send www requests to backdrop
     if (req.request ~ "^(PUT|POST|DELETE)$") {

--- a/modules/varnish/templates/directors.vcl.erb
+++ b/modules/varnish/templates/directors.vcl.erb
@@ -24,14 +24,6 @@ director read_director round-robin {
         .backend = read_backend_2;
     }
 }
-director stagecraft_director round-robin {
-    {
-        .backend = stagecraft_backend_1;
-    }
-    {
-        .backend = stagecraft_backend_2;
-    }
-}
 
 # Add a director for the frontend app servers
 # Note that Varnish currently runs on the frontend app servers,

--- a/modules/varnish/templates/probes.vcl.erb
+++ b/modules/varnish/templates/probes.vcl.erb
@@ -17,9 +17,3 @@ probe read_healthcheck {
                "User-Agent: Varnish-Healthcheck"
                "Connection: close";
 }
-probe stagecraft_healthcheck {
-    .request = "GET /_status HTTP/1.1"
-               "Host: stagecraft"
-               "User-Agent: Varnish-Healthcheck"
-               "Connection: close";
-}


### PR DESCRIPTION
Remove all the configuration for Stagecraft in Varnish.

Move the Stagecraft virtual host from the frontend boxes to the backend boxes.

This will require DNS changes. An alternative is to keep make the frontend boxes proxy the request directly to the backend boxes, but I think that's slightly more tricky.
