### PR TITLE
Monitor lumberjack app processes

### DIFF
--- a/modules/backdrop_collector/manifests/app.pp
+++ b/modules/backdrop_collector/manifests/app.pp
@@ -44,7 +44,7 @@ define backdrop_collector::app ($user, $group, $ensure) {
         create_owner => $user,
         create_group => $group,
     }
-    
+
     sensu::check { "lumberjack_is_down_for_collector-logs-for-${title}":
         command  => "/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p 'lumberjack.*collector-logs-for-${title}' -C 1 -W 1",
         interval => 60,

--- a/modules/backdrop_collector/manifests/app.pp
+++ b/modules/backdrop_collector/manifests/app.pp
@@ -34,14 +34,20 @@ define backdrop_collector::app ($user, $group, $ensure) {
     }
 
     logrotate::rule { "${title}-collector":
-      path         => "${app_path}/shared/log/*.log",
-      rotate       => 10,
-      rotate_every => 'day',
-      missingok    => true,
-      compress     => true,
-      create       => true,
-      create_mode  => '0640',
-      create_owner => $user,
-      create_group => $group,
+        path         => "${app_path}/shared/log/*.log",
+        rotate       => 10,
+        rotate_every => 'day',
+        missingok    => true,
+        compress     => true,
+        create       => true,
+        create_mode  => '0640',
+        create_owner => $user,
+        create_group => $group,
+    }
+    
+    sensu::check { "lumberjack_is_down_for_collector-logs-for-${title}":
+        command  => "/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p 'lumberjack.*collector-logs-for-${title}' -C 1 -W 1",
+        interval => 60,
+        handlers => ['default'],
     }
 }

--- a/modules/performanceplatform/manifests/app.pp
+++ b/modules/performanceplatform/manifests/app.pp
@@ -65,8 +65,18 @@ define performanceplatform::app (
   lumberjack::logshipper { "app-logs-for-${title}":
     log_files => [ "/opt/${title}/current/log/*.log.json" ],
   }
+  sensu::check { "lumberjack_is_down_for_app-logs-for-${title}":
+    command  => "/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p 'lumberjack.*app-logs-for-${title}' -C 1 -W 1",
+    interval => 60,
+    handlers => ['default'],
+  }
 
   lumberjack::logshipper { "var-logs-for-${title}":
     log_files => [ "/var/log/${title}/*.log.json"],
+  }
+  sensu::check { "lumberjack_is_down_for_var-logs-for-${title}":
+    command  => "/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p 'lumberjack.*var-logs-for-${title}' -C 1 -W 1",
+    interval => 60,
+    handlers => ['default'],
   }
 }

--- a/modules/performanceplatform/manifests/checks/clamav.pp
+++ b/modules/performanceplatform/manifests/checks/clamav.pp
@@ -11,7 +11,7 @@ class performanceplatform::checks::clamav (
     }
 
     sensu::check { 'clamav_is_down':
-      command  => "${check_clamav_running_script}",
+      command  => $check_clamav_running_script,
       interval => 60,
       handlers => ['default']
     }


### PR DESCRIPTION
If one of the lumberjack processes crashes fire a sensu alert. They are
managed with upstart so they usually come back up again. However, if
they crash coming up again too often upstart will leave them down.
