### PR TITLE
Prevent puppet autoloading from any installed gem.

### DIFF
--- a/modules/puppet/lib/puppet/provider/package/autoload_monkey_patch.rb
+++ b/modules/puppet/lib/puppet/provider/package/autoload_monkey_patch.rb
@@ -1,0 +1,10 @@
+require 'puppet/util/autoload'
+require 'puppet/util/log'
+
+Puppet::Util::Log.create({:level => :warning, :source => __FILE__, :message => "***** Monkey-patching out gem autoload feature *****"})
+
+Puppet::Util::Autoload.class_eval do
+  def self.gem_directories
+    []
+  end
+end


### PR DESCRIPTION
This has been done in govuk puppet - the reasoning as follows -

Motivation: this 'feature' causes massive slowdowns.  Disabling it
reduces the runtime on my dev vm from around 1300s to around 60s.

This 'feature' causes puppet to load extensions from any gem that happens
to be installed and provides puppet extensions.  This means that it
repeatedly searches inside every installed gem for any puppet
extensions.  Therefore puppet gets slower the more gems you have
installed.

See http://projects.puppetlabs.com/issues/7788 for details on this
'feature'.
