### PR TITLE
Rename nginx to pp_nginx

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -7,7 +7,7 @@ classes:
   - 'performanceplatform::checks::clamav'
   - 'performanceplatform::checks::stagecraft'
   - 'performanceplatform::backdrop_smoke_tests'
-  - 'performanceplatform::nginx'
+  - 'performanceplatform::pp_nginx'
   - 'performanceplatform::pip'
   - 'performanceplatform::python_lxml_deps'
   - 'python'

--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -5,7 +5,7 @@ classes:
   - 'nginx'
   - 'performanceplatform::development'
   - 'performanceplatform::mongo'
-  - 'performanceplatform::nginx'
+  - 'performanceplatform::pp_nginx'
   - 'performanceplatform::nodejs'
   - 'performanceplatform::postgresql_primary'
   - 'performanceplatform::pip'

--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -4,7 +4,7 @@ classes:
   - 'nginx'
   - 'performanceplatform::assets'
   - 'performanceplatform::checks::admin'
-  - 'performanceplatform::nginx'
+  - 'performanceplatform::pp_nginx'
   - 'performanceplatform::opbeat_proxy'
   - 'performanceplatform::pip'
   - 'performanceplatform::python_lxml_deps'

--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -3,7 +3,7 @@ classes:
     - 'performanceplatform::deploy'
     - 'performanceplatform::kibana'
     - 'performanceplatform::nodejs'
-    - 'performanceplatform::nginx'
+    - 'performanceplatform::pp_nginx'
     - 'performanceplatform::pypi'
     - 'python'
     - 'nginx'

--- a/hieradata/role-monitoring.yaml
+++ b/hieradata/role-monitoring.yaml
@@ -5,7 +5,7 @@ classes:
   - 'logstash'
   - 'nginx'
   - 'performanceplatform::monitoring'
-  - 'performanceplatform::nginx'
+  - 'performanceplatform::pp_nginx'
   - 'rabbitmq'
   - 'redis'
   - 'performanceplatform::checks::servers'

--- a/modules/performanceplatform/manifests/nginx.pp
+++ b/modules/performanceplatform/manifests/nginx.pp
@@ -1,8 +1,0 @@
-class performanceplatform::nginx {
-  include performanceplatform::nginx::logging_formats
-  include performanceplatform::nginx::status
-
-  class { 'collectd::plugin::nginx':
-    url => 'http://localhost:8433',
-  }
-}

--- a/modules/performanceplatform/manifests/pp_nginx.pp
+++ b/modules/performanceplatform/manifests/pp_nginx.pp
@@ -1,0 +1,8 @@
+class performanceplatform::pp_nginx {
+  include performanceplatform::pp_nginx::logging_formats
+  include performanceplatform::pp_nginx::status
+
+  class { 'collectd::plugin::nginx':
+    url => 'http://localhost:8433',
+  }
+}

--- a/modules/performanceplatform/manifests/pp_nginx/logging_formats.pp
+++ b/modules/performanceplatform/manifests/pp_nginx/logging_formats.pp
@@ -1,6 +1,4 @@
-class performanceplatform::nginx::logging_formats(
-) {
-
+class performanceplatform::pp_nginx::logging_formats {
   file { '/etc/nginx/conf.d/00-logging.conf':
     ensure  => present,
     source  => 'puppet:///modules/performanceplatform/nginx/logging.conf',

--- a/modules/performanceplatform/manifests/pp_nginx/status.pp
+++ b/modules/performanceplatform/manifests/pp_nginx/status.pp
@@ -1,4 +1,4 @@
-class performanceplatform::nginx::status {
+class performanceplatform::pp_nginx::status {
   file { '/etc/nginx/conf.d/01-stub-status.conf':
     ensure  => present,
     source  => 'puppet:///modules/performanceplatform/nginx/stub-status.conf',


### PR DESCRIPTION
LOL puppet. No, what's the opposite of LOL?

:cry:

Puppet's module scoping means that this can't be named the same as another module.
