### PR TITLE
Add slack handler to sensu

### DIFF
--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -172,7 +172,7 @@ class performanceplatform::monitoring (
 
   sensu::handler { 'default':
     type     => 'set',
-    handlers => ['logstash'],
+    handlers => ['logstash', 'slack'],
   }
 
   $pagerduty_api_key = hiera('pagerduty_api_key', undef)
@@ -199,6 +199,16 @@ class performanceplatform::monitoring (
     source  => 'puppet:///modules/performanceplatform/sensu_logstash_handler.rb',
     mode    => '0755',
     require => File[$notification_dir]
+  }
+
+  sensu::handler { 'slack':
+    command => '/etc/sensu/handlers/notification/slack.rb',
+    config  => {
+      token     => hiera('slack_token', ''),
+      team_name => 'gds',
+      channel   => '#alerts',
+      bot_name  => "Alerts - ${::pp_environment}",
+    },
   }
 
   sensu::handler { 'logstash':


### PR DESCRIPTION
This is hooked up to the default set, which means any alert that gets
trigger will end up being sent to slack.

It uses the environment name (pp_environment) to give the different
environment alerts a different bot name.

Slack token is stored in pp-deployment
