### PR TITLE
Fix stagecraft _status logstash filter

### DIFF
--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -119,9 +119,9 @@ class performanceplatform::monitoring (
   }
 
   logstash::filter::grep { 'ignore_stagecraft_status_request':
+    tags      => ["stagecraft"],
     match     => {
-      '@tags'             => "stagecraft",
-      '@fields.http_path' => "/_status",
+      'http_path' => "/_status",
     },
     negate    => true,
     order     => 20,


### PR DESCRIPTION
They were still finding their way through logstash. The filter syntax
for logstash is not consistent, but it is what it is.

That has been hacked in to preview to test.
