### PR TITLE
Split up different environments by channel not bot

### DIFF
--- a/modules/performanceplatform/manifests/monitoring.pp
+++ b/modules/performanceplatform/manifests/monitoring.pp
@@ -206,8 +206,8 @@ class performanceplatform::monitoring (
     config  => {
       token     => hiera('slack_token', ''),
       team_name => 'gds',
-      channel   => '#alerts',
-      bot_name  => "Alerts - ${::pp_environment}",
+      channel   => "#${::pp_environment}-alerts",
+      bot_name  => 'Alert bot 3000',
     },
   }
 


### PR DESCRIPTION
It's rather tricky to tell apart alerts for different environments with
just a varying bot name, so I've created some new channels
