### PR TITLE
Add clamav to frontend role

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -1,9 +1,11 @@
 ---
 classes:
+  - 'clamav'
   - 'collectd::plugin::varnish'
   - 'nginx'
   - 'performanceplatform::assets'
   - 'performanceplatform::checks::admin'
+  - 'performanceplatform::checks::clamav'
   - 'performanceplatform::pp_nginx'
   - 'performanceplatform::opbeat_proxy'
   - 'performanceplatform::pip'


### PR DESCRIPTION
The admin app runs on frontend-app machines and requires clamav, we now
need this to exist.

We should be able to remove it off the backend machines when backdrop
admin is retired.
