### PR TITLE
We need to add `add_header` to proxy_vhost

### DIFF
--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -29,6 +29,7 @@ define performanceplatform::proxy_vhost(
   $auth_basic           = undef,
   $auth_basic_user_file = undef,
   $block_all_robots     = true,
+  $add_header           = undef,
 ) {
 
   $graphite_servername = regsubst($servername, '\.', '_', 'G')
@@ -165,6 +166,7 @@ define performanceplatform::proxy_vhost(
     auth_basic_user_file        => $auth_basic_user_file,
     vhost_cfg_append            => $vhost_cfg_append,
     vhost_cfg_ssl_prepend       => $vhost_cfg_ssl_prepend,
+    add_header                  => $add_header,
   }
 
   if $block_all_robots {


### PR DESCRIPTION
I forgot that our vhost definitions in YAML didn't use the
nginx::resource::vhost resource and instead used our proxy_vhost. This
mean that deployment broke because we were not exposing the add_header
parameter. This commit fixes that by passing it through to the
underlying.
