### PR TITLE
Remove elasticsearch logrotate rule

### DIFF
--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -102,16 +102,6 @@ class performanceplatform::elasticsearch(
     handlers => ['default'],
   }
 
-  logrotate::rule { 'elasticsearch-rotate':
-    path         => '/var/log/elasticsearch/elasticsearch.log.*',
-    rotate       => 30,
-    rotate_every => 'day',
-    missingok    => true,
-    compress     => true,
-    create       => true,
-    create_mode  => '0640',
-  }
-
   lvm::volume { 'elasticsearch':
     ensure => 'present',
     vg     => 'data',


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/76684740

This rule has a bad glob that caused lots of files to be created.
Rotation and limiting of files will be moved to the elasticsearch
logging config when we change puppet modules.

See: https://www.pivotaltracker.com/story/show/68127986
