### PR TITLE
Add the collectd df plugin

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -113,6 +113,7 @@ classes:
   - 'apt::unattended_upgrades'
   - 'azul::repo'
   - 'collectd'
+  - 'collectd::plugin::df'
   - 'collectd::plugin::load'
   - 'collectd::plugin::processes'
   - 'collectd::plugin::write_graphite'


### PR DESCRIPTION
This defaults to collecting inode counts, which is needed for adding an
alert around running out of inodes.
