### PR TITLE
Remove df from collectd plugin list

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -151,7 +151,6 @@ lumberjack::cert_source: 'puppet:///modules/performanceplatform/logstash.pub'
 
 collectd_plugins:
   - 'cpu'
-  - 'df'
   - 'disk'
   - 'interface'
   - 'memory'


### PR DESCRIPTION
Commit cccf932 made use of the df defined type so it has to be removed
from the raw collectd::plugin list.
