### PR TITLE
Notifier should be in dir that matches repo

### DIFF
--- a/modules/performanceplatform/manifests/notifier.pp
+++ b/modules/performanceplatform/manifests/notifier.pp
@@ -4,9 +4,9 @@ class performanceplatform::notifier(
   $group,
   $cron_definition,
   $command = 'npm start',
-  $app_path = '/opt/notifier',
-  $log_path = '/var/log/notifier',
-  $config_path = '/etc/gds/notifier',
+  $app_path = '/opt/performanceplatform-notifier',
+  $log_path = '/var/log/performanceplatform-notifier',
+  $config_path = '/etc/gds/performanceplatform-notifier',
 ) {
 
   include performanceplatform::nodejs


### PR DESCRIPTION
Fabric helper functions make assumptions about the name of the directory
based in the name of the repository it is cloning from. We shouldn't
break that contract.
