### PR TITLE
Notifier command wants to run in app dir

### DIFF
--- a/modules/performanceplatform/manifests/notifier.pp
+++ b/modules/performanceplatform/manifests/notifier.pp
@@ -54,7 +54,7 @@ class performanceplatform::notifier(
 
   create_resources(cron, $cron_defs, {
     ensure      => $ensure,
-    command     => $command,
+    command     => "cd ${app_path}/current && ${command}",
     user        => $user,
     environment => 'PATH=/bin:/usr/bin:/usr/sbin',
   })


### PR DESCRIPTION
The command the notifier is likely to want to run in the directory of
the currently deployed version.
