### PR TITLE
Postgres monitoring

### DIFF
--- a/modules/pp_postgres/manifests/monitoring/base.pp
+++ b/modules/pp_postgres/manifests/monitoring/base.pp
@@ -1,0 +1,22 @@
+class pp_postgres::monitoring::base {
+  postgresql::server::config_entry { 'track_activities':
+    value => 'on',
+  }
+  postgresql::server::config_entry { 'track_counts':
+    value => 'on',
+  }
+  postgresql::server::config_entry { 'track_functions':
+    value => 'none',
+  }
+
+  postgresql::server::role { 'monitoring':
+    connection_limit => 1,
+  }
+  postgresql::server::pg_hba_rule { 'monitoring':
+    type        => 'host',
+    database    => 'all',
+    user        => 'monitoring',
+    auth_method => 'trust',
+    address     => '127.0.0.1',
+  }
+}

--- a/modules/pp_postgres/manifests/monitoring/primary.pp
+++ b/modules/pp_postgres/manifests/monitoring/primary.pp
@@ -1,0 +1,20 @@
+class pp_postgres::monitoring::primary {
+  include('pp_postgres::monitoring::base')
+
+  class {'collectd::plugin::postgresql':
+    databases => {
+      'stagecraft' => {
+        'user' => 'monitoring',
+        'password' => '',
+        'query' => ['query_plans', 'queries', 'table_states', 'disk_io' ],
+      }
+    }
+  }
+
+  # Primary should have 6 processes; main, writer, wal writer, autovacuum launcher, stats collector, wal sender
+  sensu::check { 'postgres_is_down':
+    command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p postgres -C 6 -W 6',
+    interval => 60,
+    handlers => ['default'],
+  }
+}

--- a/modules/pp_postgres/manifests/monitoring/secondary.pp
+++ b/modules/pp_postgres/manifests/monitoring/secondary.pp
@@ -1,0 +1,20 @@
+class pp_postgres::monitoring::secondary {
+  include('pp_postgres::monitoring::base')
+
+  class {'collectd::plugin::postgresql':
+    databases => {
+      'stagecraft' => {
+        'user' => 'monitoring',
+        'password' => '',
+        'query' => ['query_plans', 'queries', 'table_states', 'disk_io' ],
+      }
+    }
+  }
+
+  # Secondary should have 5 processes; main, startup, writer, stats collector, wal receiver
+  sensu::check { 'postgres_is_down':
+    command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p postgres -C 5 -W 5',
+    interval => 60,
+    handlers => ['default'],
+  }
+}

--- a/modules/pp_postgres/manifests/primary.pp
+++ b/modules/pp_postgres/manifests/primary.pp
@@ -1,8 +1,9 @@
 class pp_postgres::primary(
   $stagecraft_password,
 ) {
-  include("pp_postgres::server")
-  include("pp_postgres::backup")
+  include('pp_postgres::server')
+  include('pp_postgres::backup')
+  include('pp_postgres::monitoring::primary')
 
   pp_postgres::db { 'stagecraft':
     password => $stagecraft_password,

--- a/modules/pp_postgres/manifests/secondary.pp
+++ b/modules/pp_postgres/manifests/secondary.pp
@@ -1,8 +1,9 @@
 class pp_postgres::secondary {
-  include("pp_postgres::server")
+  include('pp_postgres::server')
+  include('pp_postgres::monitoring::secondary')
 
-  $data_dir = "/var/lib/postgresql/9.1/main"
-  $primary_host = "postgresql-primary"
+  $data_dir = '/var/lib/postgresql/9.1/main'
+  $primary_host = 'postgresql-primary'
 
   file { "${data_dir}/recovery.conf":
     ensure  => present,


### PR DESCRIPTION
Add some very basic PostgreSQL monitoring. This does not include replication monitoring as that is not provided by default.

Depends on #555 
