### PR TITLE
Fix ordering of postgres classes

### DIFF
--- a/modules/pp_postgres/manifests/server.pp
+++ b/modules/pp_postgres/manifests/server.pp
@@ -1,4 +1,5 @@
 class pp_postgres::server {
+  Class['postgresql::globals'] -> Class['postgresql::server']
   class { 'postgresql::globals':
     # Don't install from the postgresql PPA. See "postgresql::globals" @
     # See https://forge.puppetlabs.com/puppetlabs/postgresql#setup


### PR DESCRIPTION
The postgres lib devel class must not be included until after our
postgres primary class, as it inherits from postgresql::globals, and we
need to change the paramaters of this from within pp_postgres_server

Added an explicit ordering relationship within the class as well rather
than just relying on parse order.
