### PR TITLE
Reduce number of expected procs on postgresql-primary

### DIFF
--- a/modules/pp_postgres/manifests/monitoring/primary.pp
+++ b/modules/pp_postgres/manifests/monitoring/primary.pp
@@ -11,9 +11,10 @@ class pp_postgres::monitoring::primary {
     }
   }
 
-  # Primary should have 6 processes; main, writer, wal writer, autovacuum launcher, stats collector, wal sender
+  # Primary should have 5 processes for normal running; main, writer, wal writer, autovacuum launcher, stats collector
+  #   and an additional process for replication; wal sender
   sensu::check { 'postgres_is_down':
-    command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p postgres -C 6 -W 6',
+    command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p postgres -C 5 -W 5',
     interval => 60,
     handlers => ['default'],
   }


### PR DESCRIPTION
Until we have replication running we only expect to see 5 processes for
postgres.
