### PR TITLE
Postgresql fixes

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -250,3 +250,5 @@ ruby_packages:
 python_packages:
   - gds-nagios-plugins
 
+postgresql::globals::manage_package_repo: false
+postgresql::globals::version: '9.1'

--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -127,3 +127,4 @@ python_packages:
   - virtualenvwrapper
 
 pp_postgres::primary::stagecraft_password: "securem8"
+performanceplatform::development::stagecraft_password: "securem8"

--- a/modules/pp_postgres/manifests/monitoring/base.pp
+++ b/modules/pp_postgres/manifests/monitoring/base.pp
@@ -17,6 +17,6 @@ class pp_postgres::monitoring::base {
     database    => 'all',
     user        => 'monitoring',
     auth_method => 'trust',
-    address     => '127.0.0.1',
+    address     => '127.0.0.1/32',
   }
 }

--- a/modules/pp_postgres/manifests/server.pp
+++ b/modules/pp_postgres/manifests/server.pp
@@ -1,11 +1,3 @@
 class pp_postgres::server {
-  Class['postgresql::globals'] -> Class['postgresql::server']
-  class { 'postgresql::globals':
-    # Don't install from the postgresql PPA. See "postgresql::globals" @
-    # See https://forge.puppetlabs.com/puppetlabs/postgresql#setup
-    manage_package_repo => false,
-    version             => '9.1',
-  }->
-  class { 'postgresql::server':
-  }
+  include('postgresql::server')
 }


### PR DESCRIPTION
## Fix postgresql for pp-development

This is down to a parse order issue introduced by renaming the
postgresql module (and therefore making it come after the postgres dev
module). Avoided by allowing the globals we need to override to be
provided by hiera. I have chosen to put these variables in common even
though they only apply to three roles to avoid duplication.
## Postgres pg_hba expected a netmask

This can be seen a few lines above in the pg_hba, 'allow access to all
users'.
