### PR TITLE
Add PostgreSQL replication lag to collectd

### DIFF
--- a/modules/pp_postgres/manifests/monitoring/base.pp
+++ b/modules/pp_postgres/manifests/monitoring/base.pp
@@ -14,6 +14,11 @@ class pp_postgres::monitoring::base {
     connection_limit => 1,
     password_hash    => postgresql_password('monitoring', 'monitoring'),
   }
+  postgresql::server::database_grant { 'GRANT monitoring - SELECT - stagecraft':
+    privilege => 'SELECT',
+    db        => 'stagecraft',
+    role      => 'monitoring',
+  }
   postgresql::server::pg_hba_rule { 'monitoring':
     type        => 'host',
     database    => 'all',

--- a/modules/pp_postgres/manifests/monitoring/base.pp
+++ b/modules/pp_postgres/manifests/monitoring/base.pp
@@ -10,13 +10,15 @@ class pp_postgres::monitoring::base {
   }
 
   postgresql::server::role { 'monitoring':
+    login            => true,
     connection_limit => 1,
+    password_hash    => postgresql_password('monitoring', 'monitoring'),
   }
   postgresql::server::pg_hba_rule { 'monitoring':
     type        => 'host',
     database    => 'all',
     user        => 'monitoring',
-    auth_method => 'trust',
+    auth_method => 'md5',
     address     => '127.0.0.1/32',
   }
 }

--- a/modules/pp_postgres/manifests/monitoring/primary.pp
+++ b/modules/pp_postgres/manifests/monitoring/primary.pp
@@ -17,7 +17,7 @@ class pp_postgres::monitoring::primary {
   }
   collectd::plugin::postgresql::database{'stagecraft':
     user     => 'monitoring',
-    password => '',
+    password => 'monitoring',
     host     => 'localhost',
     query    => ['query_plans', 'queries', 'table_states', 'disk_io', 'replication_lag'],
   }

--- a/modules/pp_postgres/manifests/monitoring/secondary.pp
+++ b/modules/pp_postgres/manifests/monitoring/secondary.pp
@@ -3,7 +3,7 @@ class pp_postgres::monitoring::secondary {
 
   collectd::plugin::postgresql::database{'stagecraft':
     user     => 'monitoring',
-    password => '',
+    password => 'monitoring',
     host     => 'localhost',
     query    => ['query_plans', 'queries', 'table_states', 'disk_io'],
   }

--- a/modules/pp_postgres/manifests/monitoring/secondary.pp
+++ b/modules/pp_postgres/manifests/monitoring/secondary.pp
@@ -1,15 +1,11 @@
 class pp_postgres::monitoring::secondary {
   include('pp_postgres::monitoring::base')
 
-  class {'collectd::plugin::postgresql':
-    databases => {
-      'stagecraft' => {
-        'user'     => 'monitoring',
-        'password' => '',
-        'host'     => 'localhost',
-        'query'    => ['query_plans', 'queries', 'table_states', 'disk_io' ],
-      }
-    }
+  collectd::plugin::postgresql::database{'stagecraft':
+    user     => 'monitoring',
+    password => '',
+    host     => 'localhost',
+    query    => ['query_plans', 'queries', 'table_states', 'disk_io'],
   }
 
   # Secondary should have 5 processes; main, startup, writer, stats collector, wal receiver

--- a/modules/pp_postgres/templates/collectd-query-replication-status.sql.erb
+++ b/modules/pp_postgres/templates/collectd-query-replication-status.sql.erb
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION streaming_slave_check() RETURNS TABLE (client_hostname text, client_addr inet, byte_lag float)
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        client_hostname,
+        client_addr,
+        sent_offset - (replay_offset - (sent_xlog - replay_xlog) * 255 * 16 ^ 6 ) AS byte_lag
+    FROM (
+        SELECT
+            client_hostname,
+            client_addr,
+            ('x' || lpad(split_part(sent_location,   '/', 1), 8, '0'))::bit(32)::bigint AS sent_xlog,
+            ('x' || lpad(split_part(replay_location, '/', 1), 8, '0'))::bit(32)::bigint AS replay_xlog,
+            ('x' || lpad(split_part(sent_location,   '/', 2), 8, '0'))::bit(32)::bigint AS sent_offset,
+            ('x' || lpad(split_part(replay_location, '/', 2), 8, '0'))::bit(32)::bigint AS replay_offset
+        FROM pg_stat_replication
+    ) AS s; 
+$$;


### PR DESCRIPTION
Create a stored procedure to calculate the number of bytes secondaries
are lagging from the primary. This is only tracked on the primary so it
is only added to the collectd query list there.
## PLEASE DO NOT MERGE YET

This is not easy to test locally so I would like to test it on preview first. This pull request is for review only.
