### PR TITLE
Add a function to check sequence sync

### DIFF
--- a/modules/pp_postgres/files/etc/postgresql/find_bad_seqs.sql
+++ b/modules/pp_postgres/files/etc/postgresql/find_bad_seqs.sql
@@ -1,0 +1,35 @@
+DROP FUNCTION find_bad_seqs();
+DROP TYPE bad_seq_return;
+DROP TYPE seqs_record;
+
+CREATE TYPE seqs_record as (
+  table_name VARCHAR,
+  name VARCHAR
+);
+CREATE TYPE bad_seq_return as (
+  seq_name varchar,
+  max_id integer,
+  last_value integer
+);
+
+CREATE OR REPLACE FUNCTION find_bad_seqs() RETURNS SETOF bad_seq_return AS $$
+DECLARE
+  seq seqs_record%rowtype;
+  max_id integer;
+  last_value integer;
+BEGIN
+  for seq in (SELECT left(c.relname, -7) as table_name,
+                     c.relname as name
+              FROM pg_class c
+              WHERE c.relkind = 'S') loop
+
+    execute format('SELECT max(id) as max_id FROM %I', seq.table_name)
+      into max_id;
+    execute format('SELECT last_value FROM %I', seq.name)
+      into last_value;
+
+    return next row(seq.name, max_id, last_value);
+  end loop;
+END;
+$$
+LANGUAGE plpgsql;

--- a/modules/pp_postgres/manifests/primary.pp
+++ b/modules/pp_postgres/manifests/primary.pp
@@ -29,4 +29,15 @@ class pp_postgres::primary(
     replication      => true,
     connection_limit => 1,
   }
+
+  file { '/etc/postgresql/find_bad_seqs.sql':
+    source  => 'puppet:///modules/pp_postgres/etc/postgresql/find_bad_seqs.sql',
+    owner   => 'postgres',
+    require => Pp_postgres::Db['stagecraft'],
+  }
+  exec { 'add_find_bad_seqs_function':
+    command => '/usr/bin/psql stagecraft -f /etc/postgresql/find_bad_seqs.sql',
+    user    => 'postgres',
+    require => File['/etc/postgresql/find_bad_seqs.sql'],
+  }
 }


### PR DESCRIPTION
We've had an issue where sequences have got out of sync with the fields
they are being used by. This manifested as values being generated for
values that already existed in the field in tables, as these are ids
this caused a uniqueness check to fail.

This function will return all of the sequences, the last values they
generated and the maximum value of the field in the table they are used
it. User should then be able to eyeball the out of sync sequences.

This will currently break if any sequence is not in the format
[table]_id_seq for the id field in the given table. Sorry to the person
that finds this commit message and has to fix this. Maybe PostgreSQL
supports regex extraction to pull field and table name.
