### PR TITLE
Add golang to dev VM

### DIFF
--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -111,6 +111,7 @@ vhost_proxies:
 
 system_packages:
   - cmake
+  - golang
   - libcairo2-dev
   - libjpeg8-dev
   - libpango1.0-dev


### PR DESCRIPTION
For $reasons.

We will be building binaries in CI, but want the runtime on the VM.
