### PR TITLE
Add PostgreSQL replication lag to collectd

### DIFF
--- a/modules/pp_postgres/manifests/monitoring/base.pp
+++ b/modules/pp_postgres/manifests/monitoring/base.pp
@@ -9,14 +9,11 @@ class pp_postgres::monitoring::base {
     value => 'none',
   }
 
-  postgresql::server::role { 'monitoring':
-    connection_limit => 1,
-  }
   postgresql::server::pg_hba_rule { 'monitoring':
     type        => 'host',
     database    => 'all',
     user        => 'monitoring',
-    auth_method => 'trust',
+    auth_method => 'md5',
     address     => '127.0.0.1/32',
   }
 }

--- a/modules/pp_postgres/manifests/monitoring/primary.pp
+++ b/modules/pp_postgres/manifests/monitoring/primary.pp
@@ -1,14 +1,41 @@
 class pp_postgres::monitoring::primary {
   include('pp_postgres::monitoring::base')
 
-  class {'collectd::plugin::postgresql':
-    databases => {
-      'stagecraft' => {
-        'user' => 'monitoring',
-        'password' => '',
-        'query' => ['query_plans', 'queries', 'table_states', 'disk_io' ],
-      }
-    }
+  postgresql::server::role { 'monitoring':
+    login            => true,
+    connection_limit => 1,
+    password_hash    => postgresql_password('monitoring', 'monitoring'),
+  }
+  postgresql::server::database_grant { 'GRANT monitoring - CONNECT - stagecraft':
+    privilege => 'CONNECT',
+    db        => 'stagecraft',
+    role      => 'monitoring',
+  }
+  # Create procedure to check replication status if it does not exist already
+  postgresql_psql{'collectd-postgres-replication-status-function':
+    command => template('pp_postgres/collectd-query-replication-status.sql.erb'),
+    unless => 'SELECT 1 FROM pg_catalog.pg_proc p WHERE p.proname = \'streaming_slave_check\' AND pg_catalog.pg_function_is_visible(p.oid)',
+  }
+  collectd::plugin::postgresql::query{'replication_lag':
+    statement => 'SELECT client_hostname, byte_lag FROM streaming_slave_check();',
+    results   => [{
+      type           => 'gauge',
+      instanceprefix => 'replication_lag',
+      instancesfrom  => 'client_hostname',
+      valuesfrom     => 'byte_lag',
+    }],
+  }
+  collectd::plugin::postgresql::database{'stagecraft':
+    user     => 'monitoring',
+    password => 'monitoring',
+    host     => 'localhost',
+    query    => ['query_plans', 'queries', 'table_states', 'disk_io'],
+  }
+  collectd::plugin::postgresql::database{'postgres':
+    user     => 'monitoring',
+    password => 'monitoring',
+    host     => 'localhost',
+    query    => ['replication_lag'],
   }
 
   # Primary should have 5 processes for normal running; main, writer, wal writer, autovacuum launcher, stats collector

--- a/modules/pp_postgres/manifests/monitoring/secondary.pp
+++ b/modules/pp_postgres/manifests/monitoring/secondary.pp
@@ -1,15 +1,11 @@
 class pp_postgres::monitoring::secondary {
   include('pp_postgres::monitoring::base')
 
-  class {'collectd::plugin::postgresql':
-    databases => {
-      'stagecraft' => {
-        'user'     => 'monitoring',
-        'password' => '',
-        'host'     => 'localhost',
-        'query'    => ['query_plans', 'queries', 'table_states', 'disk_io' ],
-      }
-    }
+  collectd::plugin::postgresql::database{'stagecraft':
+    user     => 'monitoring',
+    password => 'monitoring',
+    host     => 'localhost',
+    query    => ['query_plans', 'queries', 'table_states', 'disk_io'],
   }
 
   # Secondary should have 5 processes; main, startup, writer, stats collector, wal receiver

--- a/modules/pp_postgres/manifests/primary.pp
+++ b/modules/pp_postgres/manifests/primary.pp
@@ -20,6 +20,9 @@ class pp_postgres::primary(
   postgresql::server::config_entry { 'wal_keep_segments':
     value => 8,
   }
+  postgresql::server::config_entry { 'log_hostname':
+    value => 'on',
+  }
   pp_postgres::hba_rule { 'replicator':
     database    => 'replication',
     auth_method => 'trust',

--- a/modules/pp_postgres/templates/collectd-query-replication-status.sql.erb
+++ b/modules/pp_postgres/templates/collectd-query-replication-status.sql.erb
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION streaming_slave_check() RETURNS TABLE (client_hostname text, client_addr inet, byte_lag float)
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        split_part(client_hostname, '.', 1),
+        client_addr,
+        sent_offset - (replay_offset - (sent_xlog - replay_xlog) * 255 * 16 ^ 6 ) AS byte_lag
+    FROM (
+        SELECT
+            client_hostname,
+            client_addr,
+            ('x' || lpad(split_part(sent_location,   '/', 1), 8, '0'))::bit(32)::bigint AS sent_xlog,
+            ('x' || lpad(split_part(replay_location, '/', 1), 8, '0'))::bit(32)::bigint AS replay_xlog,
+            ('x' || lpad(split_part(sent_location,   '/', 2), 8, '0'))::bit(32)::bigint AS sent_offset,
+            ('x' || lpad(split_part(replay_location, '/', 2), 8, '0'))::bit(32)::bigint AS replay_offset
+        FROM pg_stat_replication
+    ) AS s; 
+$$;


### PR DESCRIPTION
Create a stored procedure to calculate the number of bytes secondaries
are lagging from the primary. This is only tracked on the primary so it
is only added to the collectd query list there.
