### PR TITLE
Add server name to ntp check name

### DIFF
--- a/modules/performanceplatform/manifests/checks/server.pp
+++ b/modules/performanceplatform/manifests/checks/server.pp
@@ -35,7 +35,7 @@ define performanceplatform::checks::server (
       handlers => ['default'],
     }
 
-    sensu::check { 'check_ntp':
+    sensu::check { "check_ntp_${name}":
       command  => "/etc/sensu/community-plugins/plugins/system/check-ntp.rb -w 2 -c 3",
       interval => 3600,
       handlers => ['default']


### PR DESCRIPTION
We create a check per server on the monitoring machine so we need the
server name in the check name.
