### PR TITLE
Remove monitoring connection limit

### DIFF
--- a/modules/pp_postgres/manifests/monitoring/primary.pp
+++ b/modules/pp_postgres/manifests/monitoring/primary.pp
@@ -3,7 +3,6 @@ class pp_postgres::monitoring::primary {
 
   postgresql::server::role { 'monitoring':
     login            => true,
-    connection_limit => 1,
     password_hash    => postgresql_password('monitoring', 'monitoring'),
   }
   postgresql::server::database_grant { 'GRANT monitoring - CONNECT - stagecraft':


### PR DESCRIPTION
Collectd makes more than one connection, also, this role can conly be
used locally and is not particularly priviledged so there really isn't
any point in restricting it.
