### PR TITLE
Move the ntp check to be on each server

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -131,6 +131,7 @@ classes:
   - 'ufw'
   - 'performanceplatform::base'
   - 'performanceplatform::checks::apt'
+  - 'performanceplatform::checks::ntp'
   - 'performanceplatform::pp_fail2ban'
 
 apt::always_apt_update: true

--- a/modules/performanceplatform/manifests/checks/ntp.pp
+++ b/modules/performanceplatform/manifests/checks/ntp.pp
@@ -1,0 +1,10 @@
+class performanceplatform::checks::ntp (
+) {
+
+  sensu::check { "check_ntp":
+    command  => '/etc/sensu/community-plugins/plugins/system/check-ntp.rb -w 2 -c 3',
+    interval => 3600,
+    handlers => ['default']
+  }
+
+}

--- a/modules/performanceplatform/manifests/checks/server.pp
+++ b/modules/performanceplatform/manifests/checks/server.pp
@@ -34,10 +34,4 @@ define performanceplatform::checks::server (
       interval => 60,
       handlers => ['default'],
     }
-
-    sensu::check { "check_ntp_${name}":
-      command  => "/etc/sensu/community-plugins/plugins/system/check-ntp.rb -w 2 -c 3",
-      interval => 3600,
-      handlers => ['default']
-    }
 }


### PR DESCRIPTION
Rather than having lots of checks on the monitoring server that all do
the same thing.
