### PR TITLE
Check skew more frequently

### DIFF
--- a/modules/performanceplatform/manifests/checks/ntp.pp
+++ b/modules/performanceplatform/manifests/checks/ntp.pp
@@ -3,7 +3,7 @@ class performanceplatform::checks::ntp (
 
   sensu::check { "check_ntp":
     command  => '/etc/sensu/community-plugins/plugins/system/check-ntp.rb -w 2 -c 3',
-    interval => 3600,
+    interval => '60',
     handlers => ['default']
   }
 


### PR DESCRIPTION
There have been a few alerts show up on clock skew, but by the time of
checking them they are resolved. We may also need to tune the warning /
critical threshold, but this change means minor clock skew shouldnt
end up with critical production alerts for 1 hour after the case (until
the check runs again)
