### PR TITLE
Monitor the postgresql secondary machine

### DIFF
--- a/hieradata/role-monitoring.yaml
+++ b/hieradata/role-monitoring.yaml
@@ -30,6 +30,7 @@ performanceplatform::checks::servers::boxes:
   - logs-elasticsearch-1
   - logs-elasticsearch-2
   - postgresql-primary-1
+  - postgresql-secondary-1
 
 collectd::plugin::processes::process_matches:
   - name: 'logstash'


### PR DESCRIPTION
Because, you know, having some insight into whether it is alive is a
good idea.
