### PR TITLE
Use nginx version from our PPA everywhere

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -21,6 +21,8 @@ ufw_rules:
 
 nginx::confd_purge: true
 nginx::vhost_purge: true
+nginx::manage_repo: false
+nginx::package_ensure: '1.4.4-4~precise0'
 
 performanceplatform::notifier::user: 'deploy'
 performanceplatform::notifier::group: 'deploy'

--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -61,6 +61,8 @@ ufw_rules:
 nginx::names_hash_bucket_size: 128
 nginx::confd_purge: true
 nginx::vhost_purge: true
+nginx::manage_repo: false
+nginx::package_ensure: '1.4.4-4~precise0'
 
 vhost_proxies:
   # For spotlight

--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -60,6 +60,8 @@ ufw_rules:
 nginx::names_hash_bucket_size: 128
 nginx::confd_purge: true
 nginx::vhost_purge: true
+nginx::manage_repo: false
+nginx::package_ensure: '1.4.4-4~precise0'
 nginx::http_cfg_append:
   gzip_types: application/x-javascript application/javascript application/json text/css
   gzip_proxied: no_etag

--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -13,6 +13,8 @@ classes:
 nginx::names_hash_bucket_size: 128
 nginx::confd_purge: true
 nginx::vhost_purge: true
+nginx::manage_repo: false
+nginx::package_ensure: '1.4.4-4~precise0'
 
 performanceplatform::jenkins::lts: 1
 performanceplatform::jenkins::plugin_hash:

--- a/hieradata/role-monitoring.yaml
+++ b/hieradata/role-monitoring.yaml
@@ -15,6 +15,8 @@ classes:
 
 nginx::confd_purge: true
 nginx::vhost_purge: true
+nginx::manage_repo: false
+nginx::package_ensure: '1.4.4-4~precise0'
 
 performanceplatform::checks::servers::boxes:
   - backend-app-1

--- a/modules/performanceplatform/manifests/pp_nginx.pp
+++ b/modules/performanceplatform/manifests/pp_nginx.pp
@@ -5,4 +5,15 @@ class performanceplatform::pp_nginx {
   class { 'collectd::plugin::nginx':
     url => 'http://localhost:8433',
   }
+
+  file { '/etc/apt/sources.list.d/nginx.list':
+    ensure => 'absent',
+    notify  => Exec['apt_update'],
+  }
+
+  file { '/etc/apt/sources.list.d/teward-nginx-devel-testing-precise.list':
+    ensure => 'absent',
+    notify  => Exec['apt_update'],
+  }
+
 }


### PR DESCRIPTION
- remove nginx Apt repo so that later versions aren't installed
- use our version (from ubuntu repo)

This is preparatory work so that we can use nginx-extra and thus use
lua/Perl to do stuff.

This should be carefully deployed, since we have terrible
inconsistencies in the versions that we have in different environments.
