### PR TITLE
Add a request ID to all the things

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -23,6 +23,7 @@ nginx::confd_purge: true
 nginx::vhost_purge: true
 nginx::manage_repo: false
 nginx::package_ensure: '1.4.4-4~precise0'
+nginx::package_name: 'nginx-extras'
 
 performanceplatform::notifier::user: 'deploy'
 performanceplatform::notifier::group: 'deploy'

--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -6,6 +6,7 @@ classes:
   - 'performanceplatform::development'
   - 'performanceplatform::mongo'
   - 'performanceplatform::pp_nginx'
+  - 'performanceplatform::pp_nginx::request_uuid'
   - 'performanceplatform::nodejs'
   - 'performanceplatform::pip'
   - 'performanceplatform::python_lxml_deps'
@@ -63,6 +64,7 @@ nginx::confd_purge: true
 nginx::vhost_purge: true
 nginx::manage_repo: false
 nginx::package_ensure: '1.4.4-4~precise0'
+nginx::package_name: 'nginx-extras'
 
 vhost_proxies:
   # For spotlight

--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -7,6 +7,7 @@ classes:
   - 'performanceplatform::checks::admin'
   - 'performanceplatform::checks::clamav'
   - 'performanceplatform::pp_nginx'
+  - 'performanceplatform::pp_nginx:request_uuid'
   - 'performanceplatform::opbeat_proxy'
   - 'performanceplatform::pip'
   - 'performanceplatform::python_lxml_deps'
@@ -62,6 +63,7 @@ nginx::confd_purge: true
 nginx::vhost_purge: true
 nginx::manage_repo: false
 nginx::package_ensure: '1.4.4-4~precise0'
+nginx::package_name: 'nginx-extras'
 nginx::http_cfg_append:
   gzip_types: application/x-javascript application/javascript application/json text/css
   gzip_proxied: no_etag

--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -15,6 +15,7 @@ nginx::confd_purge: true
 nginx::vhost_purge: true
 nginx::manage_repo: false
 nginx::package_ensure: '1.4.4-4~precise0'
+nginx::package_name: 'nginx-extras'
 
 performanceplatform::jenkins::lts: 1
 performanceplatform::jenkins::plugin_hash:

--- a/hieradata/role-monitoring.yaml
+++ b/hieradata/role-monitoring.yaml
@@ -17,6 +17,7 @@ nginx::confd_purge: true
 nginx::vhost_purge: true
 nginx::manage_repo: false
 nginx::package_ensure: '1.4.4-4~precise0'
+nginx::package_name: 'nginx-extras'
 
 performanceplatform::checks::servers::boxes:
   - backend-app-1

--- a/modules/performanceplatform/files/nginx/request-uuid.conf
+++ b/modules/performanceplatform/files/nginx/request-uuid.conf
@@ -1,0 +1,6 @@
+perl_require "Data/UUID.pm";
+perl_set $request_uuid 'sub {
+
+  my $ug = new Data::UUID;
+  return $ug->create_str();
+}';

--- a/modules/performanceplatform/manifests/pp_nginx.pp
+++ b/modules/performanceplatform/manifests/pp_nginx.pp
@@ -16,4 +16,8 @@ class performanceplatform::pp_nginx {
     notify => Exec['apt_update'],
   }
 
+  package { 'nginx-full':
+    ensure => 'absent',
+  }
+
 }

--- a/modules/performanceplatform/manifests/pp_nginx/request_uuid.pp
+++ b/modules/performanceplatform/manifests/pp_nginx/request_uuid.pp
@@ -1,0 +1,12 @@
+class performanceplatform::pp_nginx::request_uuid {
+  package { 'libossp-uuid-perl':
+    ensure => installed,
+  }
+
+  file { '/etc/nginx/conf.d/02-request-uuid.conf':
+    ensure  => present,
+    source  => 'puppet:///modules/performanceplatform/nginx/request-uuid.conf',
+    require => Class['nginx::config'],
+    notify  => Service['nginx'],
+  }
+}

--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -31,6 +31,7 @@ define performanceplatform::proxy_vhost(
   $block_all_robots     = true,
   $add_header           = undef,
   $custom_locations     = undef,
+  $request_uuid_servernames = [],
 ) {
 
   $graphite_servername = regsubst($servername, '\.', '_', 'G')
@@ -136,9 +137,17 @@ define performanceplatform::proxy_vhost(
       # Set an HSTS header to enforce SSL for 1 month
       'add_header' => 'Strict-Transport-Security "max-age=2628000"',
     }
+    if $servername in $request_uuid_servernames {
+      $request_id = [
+        'Request-Id $request_uuid',
+      ]
+    } else {
+      $request_id = []
+    }
   } else {
     $forwarded_proto = []
     $vhost_cfg_ssl_prepend = undef
+    $request_id = []
   }
 
   if $denied_http_verbs and !empty($denied_http_verbs) {


### PR DESCRIPTION
As person responsible for operating software in production
I would like to have a unique ID associated with every request
So that it is easy for me to track down problems in a distributed
system.

This is the first step to that. Every request coming in to our SSL
termination machines will have a UUID assigned to it with an HTTP
header.

We can then amend our logging to include this header where appropriate
and make it easier to trace requests going through the system.

This removes nginx-full and replaces it with nginx-extras.
