### PR TITLE
Undo namespace fix for mongo_hosts

### DIFF
--- a/modules/performanceplatform/manifests/mongo.pp
+++ b/modules/performanceplatform/manifests/mongo.pp
@@ -60,8 +60,8 @@ rs.initiate(replicaSetConfig());
 "
     }
     exec { 'configure-replica-set':
-      command => "echo '/usr/bin/mongo --host ${::mongo_hosts[0]} /etc/mongodb/configure-replica-set.js' | at now + 3min",
-      unless  => "/usr/bin/mongo --host ${::mongo_hosts[0]} --quiet --eval 'rs.status().ok' | grep -q 1",
+      command => "echo '/usr/bin/mongo --host ${mongo_hosts[0]} /etc/mongodb/configure-replica-set.js' | at now + 3min",
+      unless  => "/usr/bin/mongo --host ${mongo_hosts[0]} --quiet --eval 'rs.status().ok' | grep -q 1",
       require => [
         File['/etc/mongodb/configure-replica-set.js'],
         Service['mongodb'],


### PR DESCRIPTION
This is not a global variable, it's passed into the class. I have no
idea why the linter is complaining.
