### PR TITLE
We've replace nginx package for nginx-extra

### DIFF
--- a/modules/performanceplatform/manifests/deploy.pp
+++ b/modules/performanceplatform/manifests/deploy.pp
@@ -18,7 +18,7 @@ class performanceplatform::deploy (
         file { '/etc/nginx/htpasswd.pp':
             ensure  => present,
             content => $basic_auth,
-            require => Package['nginx'],
+            require => Package['nginx-extra'],
         }
     }
     if ($jenkins_key) {


### PR DESCRIPTION
As part of adding request-id headers to our stack we switched over to
using the nginx-extra package for its perl extensions.
