### PR TITLE
Set Request-Id using a boolean flag

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -86,6 +86,7 @@ vhost_proxies:
     servername:    "%{::admin_vhost}"
     ssl:           true
     ssl_redirect:  true
+    request_uuid:  true
     upstream_port: 7999
     four_warning: 1
     four_critical: 3
@@ -98,6 +99,7 @@ vhost_proxies:
     servername:    "%{::admin_beta_vhost}"
     ssl:           true
     ssl_redirect:  true
+    request_uuid:  true
     upstream_port: 3070
     four_warning: 1
     four_critical: 3
@@ -116,6 +118,7 @@ vhost_proxies:
     servername:    "%{::www_vhost}"
     ssl:           true
     ssl_redirect:  true
+    request_uuid:  true
     upstream_port: 7999
     four_warning: 1
     four_critical: 3

--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -31,8 +31,10 @@ define performanceplatform::proxy_vhost(
   $block_all_robots     = true,
   $add_header           = undef,
   $custom_locations     = undef,
-  $request_uuid_servernames = [],
+  $request_uuid         = false,
 ) {
+
+  validate_bool($request_uuid)
 
   $graphite_servername = regsubst($servername, '\.', '_', 'G')
 
@@ -137,16 +139,16 @@ define performanceplatform::proxy_vhost(
       # Set an HSTS header to enforce SSL for 1 month
       'add_header' => 'Strict-Transport-Security "max-age=2628000"',
     }
-    if $servername in $request_uuid_servernames {
-      $request_id = [
-        'Request-Id $request_uuid',
-      ]
-    } else {
-      $request_id = []
-    }
   } else {
     $forwarded_proto = []
     $vhost_cfg_ssl_prepend = undef
+  }
+
+  if $request_uuid {
+    $request_id = [
+      'Request-Id $request_uuid',
+    ]
+  } else {
     $request_id = []
   }
 


### PR DESCRIPTION
I misunderstood how puppet params work. I thought that defining them as
an array in hiera would be fine, but that doesn’t appear to be the case.
I think this is due to how we use vhost_proxies in nodes.pp.

Instead, added a flag with a default value to proxy_vhost and set it for
the vhosts that we care about.

Tested with frontend-app-1 in Vagrant.
