### PR TITLE
Reduce SSL Sensu check frequency

### DIFF
--- a/modules/performanceplatform/manifests/checks/ssl.pp
+++ b/modules/performanceplatform/manifests/checks/ssl.pp
@@ -5,7 +5,7 @@ class performanceplatform::checks::ssl () {
 
   sensu::check { 'ssl_expiry_check':
     command  => "${check_https_path} -h www.${domain_name} -p 443 -c 30 -w 40",
-    interval => 120,
+    interval => 86400,
     handlers => ['default'],
   }
 


### PR DESCRIPTION
The alert goes critical 28 days before the SSL cert expires so that we
have plenty of time to organise renewing it. The alert unresolves itself
every time it's run. These two facts combined make having high check
frequency very very annoying.
