### PR TITLE
Add Naginator plugin

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -37,6 +37,8 @@ performanceplatform::jenkins::plugin_hash:
         version: "1.1.2"
     greenballs:
         version: "1.12"
+    naginator:
+        version: "1.12"
 
 performanceplatform::kibana::elasticsearch_url: "https://%{::elasticsearch_vhost}"
 performanceplatform::kibana::tarball_url: 'https://download.elasticsearch.org/kibana/kibana/kibana-3.0.0milestone4.tar.gz'


### PR DESCRIPTION
The [naginator
plugin](https://wiki.jenkins-ci.org/display/JENKINS/Naginator+Plugin)
allows us to retry failed builds. Its only intended for use with the
smokey tests which fail due to an interaction with signon that we are
not in control of. To start with we would set this job to retry once. If
there was a failure not due to signon, the build will still fail as
normal - this plugin will only help if the failure is temporary.
