### PR TITLE
Instally ruby dev as well as ruby

### DIFF
--- a/tools/bootstrap-vagrant
+++ b/tools/bootstrap-vagrant
@@ -28,10 +28,12 @@ set_dns_server() {
 
 check_ruby() {
   echo "--> Check for Ruby" | pp
-  if ! dpkg -s ruby1.9.1 >/dev/null 2>&1; then
-    apt-get update -qq
-    apt-get install -qq ruby1.9.1 2>&1 | pp
-  fi
+  for package in ruby1.9.1{,-dev}; do
+    if ! dpkg -s $package >/dev/null 2>&1; then
+      apt-get update -qq
+      apt-get install -qq $package 2>&1 | pp
+    fi
+  done
 }
 
 check_bundler() {


### PR DESCRIPTION
When bootstrapping machines make sure ruby 1.9.1-dev is installed to
prevent erors installing the json gem
