### PR TITLE
Change version of plugin to 1.8

### DIFF
--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -38,7 +38,7 @@ performanceplatform::jenkins::plugin_hash:
     greenballs:
         version: "1.12"
     naginator:
-        version: "1.12"
+        version: "1.8"
 
 performanceplatform::kibana::elasticsearch_url: "https://%{::elasticsearch_vhost}"
 performanceplatform::kibana::tarball_url: 'https://download.elasticsearch.org/kibana/kibana/kibana-3.0.0milestone4.tar.gz'


### PR DESCRIPTION
This should work in all the jenkins versions we currently use. 1.12
requires a newer jenkins version. For future plugins its worth checking
the latest version available in the update centre in production jenkins
(the earliest version) and using that as the one to use.
