### PR TITLE
Generate Request-Id header for spotlight

### DIFF
--- a/modules/performanceplatform/manifests/app.pp
+++ b/modules/performanceplatform/manifests/app.pp
@@ -1,3 +1,10 @@
+# === Parameters
+#
+# [*request_uuid*]
+#   Optional boolean value. Whether to proxy_set_header the $request_uuid value or not.
+#   If set, this can be used to trace a request through all the systems that collaborate
+#   to service a single external request
+#
 define performanceplatform::app (
   $port                        = undef,
   $workers                     = 4,
@@ -18,7 +25,11 @@ define performanceplatform::app (
   $statsd_prefix               = $title,
   $ssl_cert                    = hiera('public_ssl_cert'),
   $ssl_key                     = hiera('public_ssl_key'),
+  $request_uuid                = false,
 ) {
+
+  validate_bool($request_uuid)
+
   include nginx
   include upstart
 
@@ -42,6 +53,7 @@ define performanceplatform::app (
     proxy_append_forwarded_host => $proxy_append_forwarded_host,
     proxy_set_forwarded_host    => $proxy_set_forwarded_host,
     client_max_body_size        => $client_max_body_size,
+    request_uuid                => $request_uuid,
   }
 
   $base_environment = {

--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -39,8 +39,15 @@ define performanceplatform::proxy_vhost(
   $custom_locations     = undef,
   $request_uuid         = false,
 ) {
-
+  
+  validate_bool($block_all_robots)
+  validate_bool($pp_only_vhost)
+  validate_bool($proxy_append_forwarded_host)
+  validate_bool($forward_host_header)
   validate_bool($request_uuid)
+  validate_bool($sensu_check)
+  validate_bool($ssl)
+  validate_array($denied_http_verbs)
 
   $graphite_servername = regsubst($servername, '\.', '_', 'G')
 

--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -1,3 +1,10 @@
+# === Parameters
+#
+# [*request_uuid*]
+#   Optional boolean value. Whether to proxy_set_header the $request_uuid value or not.
+#   If set, this can be used to trace a request through all the systems that collaborate
+#   to service a single external request
+#
 define performanceplatform::proxy_vhost(
   $port                = '80',
   $priority            = '10',

--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -8,7 +8,6 @@
 define performanceplatform::proxy_vhost(
   $port                = '80',
   $priority            = '10',
-  $template            = 'nginx/vhost-proxy.conf.erb',
   $upstream_server     = 'localhost',
   $upstream_hostname   = undef,
   $upstream_port       = '8080',

--- a/modules/spotlight/manifests/app.pp
+++ b/modules/spotlight/manifests/app.pp
@@ -24,6 +24,7 @@ class spotlight::app (
     upstart_desc                => 'Spotlight job',
     upstart_exec                => 'node --trace-gc app/server.js',
     proxy_append_forwarded_host => false,
+    request_uuid                => true,
   }
 
   nginx::resource::location { 'spotlight-app-assets':


### PR DESCRIPTION
The networking is…interesting. We have:

```
GET /performance
Host www.gov.uk
```

over the public internet goes through CDN to GOV.UK origin servers.

Here it hits the [router](https://github.com/alphagov/router).

The router looks up data in the[router-api](https://github.com/alphagov/router-api) to decide which
backend handles that request. Currently this is the spotlight backend. It
then goes via a local `dnsmasq` | `/etc/hosts` lookup to the GOV.UK frontend
loadbalancer, where it is then proxied via ngxinx to the Performance
Platform environment.
