### PR TITLE
Force ntp panic off

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -179,6 +179,7 @@ ntp::servers:
   - '0.uk.pool.ntp.org'
   - '1.uk.pool.ntp.org'
   - '2.uk.pool.ntp.org'
+ntp::panic: false
 
 performanceplatform::dns::hosts: |
   172.27.1.2  jumpbox-1 jenkins


### PR DESCRIPTION
Panic should be off for virtual machines [1]. However, facter isn't
picking up that our machines are virtual.

[1]
http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1006427
