### PR TITLE
Set tcp keepalive to 300s on Mongo machines

### DIFF
--- a/modules/performanceplatform/manifests/mongo.pp
+++ b/modules/performanceplatform/manifests/mongo.pp
@@ -69,6 +69,13 @@ rs.initiate(replicaSetConfig());
       ],
     }
 
+    # MongoDB works best with a lower tcp keepalive
+    # http://docs.mongodb.org/manual/faq/diagnostics/#does-tcp-keepalive-time-affect-sharded-clusters-and-replica-sets
+    exec { 'set-tcp_keepalive_time':
+      command => 'echo 300 > /proc/sys/net/ipv4/tcp_keepalive_time',
+      unless  => '[ "300" = "$(cat /proc/sys/net/ipv4/tcp_keepalive_time)" ]',
+    }
+
     $escaped_fqdn = regsubst($::fqdn, '\.', '_', 'G')
 
     sensu::check { "mongod_is_down_${escaped_fqdn}":
@@ -77,6 +84,7 @@ rs.initiate(replicaSetConfig());
       handlers => ['default'],
     }
 
+    # MongoDB collectd plugin
     vcsrepo { '/etc/collectd/plugins/mongodb':
         ensure   => present,
         provider => git,


### PR DESCRIPTION
We started seeing socket errors and had a mongo machine die. We're not
exactly sure if the socket errors were the cause but they were the last
error in the logs. The FAQ entry below suggests lowering the tcp
keepalive.
http://docs.mongodb.org/manual/faq/diagnostics/#does-tcp-keepalive-time-affect-sharded-clusters-and-replica-sets
