### PR TITLE
Don’t show version of nginx in Server header

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -24,6 +24,7 @@ nginx::vhost_purge: true
 nginx::manage_repo: false
 nginx::package_ensure: '1.4.4-4~precise0'
 nginx::package_name: 'nginx-extras'
+nginx::server_tokens: 'off'
 
 performanceplatform::notifier::user: 'deploy'
 performanceplatform::notifier::group: 'deploy'

--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -66,6 +66,7 @@ nginx::vhost_purge: true
 nginx::manage_repo: false
 nginx::package_ensure: '1.4.4-4~precise0'
 nginx::package_name: 'nginx-extras'
+nginx::server_tokens: 'off'
 
 vhost_proxies:
   # For spotlight

--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -65,6 +65,7 @@ nginx::vhost_purge: true
 nginx::manage_repo: false
 nginx::package_ensure: '1.4.4-4~precise0'
 nginx::package_name: 'nginx-extras'
+nginx::server_tokens: 'off'
 nginx::http_cfg_append:
   gzip_types: application/x-javascript application/javascript application/json text/css
   gzip_proxied: no_etag

--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -16,6 +16,7 @@ nginx::vhost_purge: true
 nginx::manage_repo: false
 nginx::package_ensure: '1.4.4-4~precise0'
 nginx::package_name: 'nginx-extras'
+nginx::server_tokens: 'off'
 
 performanceplatform::jenkins::lts: 1
 performanceplatform::jenkins::plugin_hash:

--- a/hieradata/role-monitoring.yaml
+++ b/hieradata/role-monitoring.yaml
@@ -18,6 +18,7 @@ nginx::vhost_purge: true
 nginx::manage_repo: false
 nginx::package_ensure: '1.4.4-4~precise0'
 nginx::package_name: 'nginx-extras'
+nginx::server_tokens: 'off'
 
 performanceplatform::checks::servers::boxes:
   - backend-app-1


### PR DESCRIPTION
Slightly moot point, since our stuff is mainly coding in the open, but
a minor security best practice.
