### PR TITLE
Re-use Request-Id if there is one

### DIFF
--- a/modules/performanceplatform/files/nginx/request-uuid.conf
+++ b/modules/performanceplatform/files/nginx/request-uuid.conf
@@ -1,6 +1,10 @@
 perl_require "Data/UUID.pm";
 perl_set $request_uuid 'sub {
 
+  my $r = shift;
+  my $id = $r->header_in("Request-Id");
+  return $id if (length $id);
+
   my $ug = new Data::UUID;
   return $ug->create_str();
 }';


### PR DESCRIPTION
Spotlight makes requests to the public FQDN for backdrop, and tries to
pass the Request-Id that was set by the SSL termination along. We should
proxy that through as well, so that we have a single (hopefully unique)
ID for all requests.

This does mean that we’re trusting content from the internet. We can do
something more if this turns out to be a problem / abused.
