### PR TITLE
Upgrade Node.js from 0.10.29 to 0.10.32

### DIFF
--- a/modules/performanceplatform/manifests/nodejs.pp
+++ b/modules/performanceplatform/manifests/nodejs.pp
@@ -1,6 +1,6 @@
 class performanceplatform::nodejs {
   package { 'nodejs':
-    ensure  => "0.10.29-1chl1~${::lsbdistcodename}1",
+    ensure  => "0.10.32-1chl1~${::lsbdistcodename}1",
     require => Apt::Ppa['ppa:gds/performance-platform'],
   }
   package { 'grunt-cli':


### PR DESCRIPTION
This package exists in our PPA. We should update to it so that we can use other people's newest, shiniest code.
