### PR TITLE
Dont run apt updates in development

### DIFF
--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -136,3 +136,4 @@ python_packages:
 
 pp_postgres::primary::stagecraft_password: "securem8"
 performanceplatform::development::stagecraft_password: "securem8"
+apt::always_apt_update: false


### PR DESCRIPTION
This adds time to the puppet run and we dont really mind if dev vms are
not up to date
