### PR TITLE
Fix mongo on dev vm

### DIFF
--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -137,3 +137,5 @@ python_packages:
 pp_postgres::primary::stagecraft_password: "securem8"
 performanceplatform::development::stagecraft_password: "securem8"
 apt::always_apt_update: false
+performanceplatform::mongo::data_dir: '/var/lib/mongodb'
+performanceplatform::mongo::require_logshipper: false


### PR DESCRIPTION
- Dont try and mount a non existent disk
  - Move relationship requiring the mount before mongo to the mount
    itself so we dont require something that doesnt exist
  - Add a hacky extra parameter to require the logshipper config - need
    to do this because the logshipper stuff is defined in hiera, which
    doesnt let us set relationship information, and we cant setup
    logshipper until the mongo log file exists. Cant setup logshipper on
    the dev vm as there is no logstash instance running.
