### PR TITLE
Upgrade puppet to version 3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
 source 'https://rubygems.org'
 
-gem 'puppet', '3.4.3'
+gem 'puppet', '3.5.1'
 gem 'hiera', '1.3.4'
 gem 'librarian-puppet', '1.1.3'
 
 group :build do
-    gem 'facter', '1.7.5'
+    gem 'facter'
     gem 'hiera-puppet-helper'
     gem 'puppet-lint', '1.0.1'
     gem 'puppet-syntax'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.2.8)
     activemodel (4.1.4)
       activesupport (= 4.1.4)
       builder (~> 3.1)
@@ -12,7 +13,8 @@ GEM
       tzinfo (~> 1.1)
     builder (3.2.2)
     diff-lcs (1.2.5)
-    facter (1.7.5)
+    facter (2.2.0)
+      CFPropertyList (~> 2.2.6)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
     her (0.7.2)
@@ -41,9 +43,11 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.10.1)
     multipart-post (2.0.0)
-    puppet (3.4.3)
-      facter (~> 1.6)
+    puppet (3.5.1)
+      facter (> 1.6, < 3)
       hiera (~> 1.0)
+      json_pure
+      rgen (~> 0.6.5)
     puppet-lint (1.0.1)
     puppet-syntax (1.1.1)
       puppet (>= 2.7.0)
@@ -56,6 +60,7 @@ GEM
       rspec (>= 2.9.0)
       rspec-puppet (>= 0.1.1)
     rake (10.1.1)
+    rgen (0.6.6)
     rspec (2.99.0)
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
@@ -81,11 +86,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  facter (= 1.7.5)
+  facter
   hiera (= 1.3.4)
   hiera-puppet-helper
   librarian-puppet (= 1.1.3)
-  puppet (= 3.4.3)
+  puppet (= 3.5.1)
   puppet-lint (= 1.0.1)
   puppet-syntax
   puppetlabs_spec_helper (~> 0.4)

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -6,4 +6,3 @@ File {
   group => 'root',
 }
 
-import 'nodes.pp'

--- a/tools/puppet-apply
+++ b/tools/puppet-apply
@@ -4,4 +4,4 @@ set -eu
 cd "$(dirname $0)/.."
 exec ./bin/puppet apply --modulepath=modules:vendor/modules \
                         --hiera_config=hiera.yaml \
-                        manifests/site.pp
+                        manifests


### PR DESCRIPTION
Opening for discussion - i've had success running with 3.5 on mongo-1 and 
development-1 in vagrant. I'd suggest deploying this branch on preview and
seeing what issues arise, if people are happy with that.

Upgrading to 3.6 didnt seem to work immediately on development-1 - seems it 
might be a quick win to upgrade to 3.5 (assuming things work on preview)
