### PR TITLE
Remove SSLv3 from nginx

### DIFF
--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -180,6 +180,7 @@ define performanceplatform::proxy_vhost(
     proxy                 => "http://${upstream_name}",
     ssl                   => $ssl,
     ssl_port              => $ssl_port,
+    ssl_protocols         => 'TLSv1 TLSv1.1 TLSv1.2',
     ssl_cert              => "${ssl_path}/${ssl_cert}",
     ssl_key               => "${ssl_path}/${ssl_key}",
     rewrite_to_https      => $ssl_redirect,


### PR DESCRIPTION
The default enables SSLv3.

https://github.com/jfryman/puppet-nginx/blob/v0.0.9/manifests/resource/vhost.pp#L53-L54

This is no longer a sensible default: SSLv3 is ancient and now has a
published vulnerability in the design.

http://googleonlinesecurity.blogspot.co.uk/2014/10/this-poodle-bites-exploiting-ssl-30.html

By doing this, we prevent people running IE6 on WinXP lower than SP3
from accessing our service. Unfortunately, security concerns mean that
we need to make this change.
