### PR TITLE
Bump warning threshold of our ntp check to 30ms

### DIFF
--- a/modules/performanceplatform/manifests/checks/ntp.pp
+++ b/modules/performanceplatform/manifests/checks/ntp.pp
@@ -2,7 +2,7 @@ class performanceplatform::checks::ntp (
 ) {
 
   sensu::check { 'check_ntp':
-    command  => '/etc/sensu/community-plugins/plugins/system/check-ntp.rb -w 10 -c 100',
+    command  => '/etc/sensu/community-plugins/plugins/system/check-ntp.rb -w 30 -c 100',
     interval => '60',
     handlers => ['default']
   }


### PR DESCRIPTION
- I'm bumping it to `30ms`, though even this may be too low...

Running `ntpq -p` will bring back a result set that looks a bit like:

```
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
+juniperberry.ca 193.79.237.14    2 u  646 1024  377    5.709  -27.140  41.061
*time.euro.apple 17.72.133.55     2 u  596 1024  377   18.190  -26.064  40.024
+mail1.ugh.no    0.104.50.214     3 u  311 1024  377    4.973   -0.319  26.603
+97e14b87.skybro 81.2.117.235     2 u  546 1024  377   22.755  -25.311  39.323
+kvm01-vps.cleve 129.215.42.240   3 u   88 1024  377    5.794  -18.555  33.644
 LOCAL(0)        .LOCL.          10 l   5d   64    0    0.000    0.000   0.000
```

So there are some `> 10ms` offsets in here but as my esteemed colleague and ntp agitator @philandstuff has pointed out, we're looking at a machine that is synced to five upstream clocks. Nothing bad enough is happening here that requires the attention of a webop as far as I can tell.
