### PR TITLE
Increase margin for NTP error

### DIFF
--- a/modules/performanceplatform/manifests/checks/ntp.pp
+++ b/modules/performanceplatform/manifests/checks/ntp.pp
@@ -2,7 +2,7 @@ class performanceplatform::checks::ntp (
 ) {
 
   sensu::check { 'check_ntp':
-    command  => '/etc/sensu/community-plugins/plugins/system/check-ntp.rb -w 10 -c 100',
+    command  => '/etc/sensu/community-plugins/plugins/system/check-ntp.rb -w 100 -c 200',
     interval => '60',
     handlers => ['default']
   }


### PR DESCRIPTION
10ms is too low and keeps flapping.
