### PR TITLE
Disable Mongo HTTP interface

### DIFF
--- a/modules/performanceplatform/manifests/mongo.pp
+++ b/modules/performanceplatform/manifests/mongo.pp
@@ -20,6 +20,7 @@ class performanceplatform::mongo (
         logpath         => '/var/log/mongodb/mongodb.log',
         dbpath          => $data_dir,
         before          => $before,
+        nohttpinterface => true,
     }
 
 


### PR DESCRIPTION
MongoDB by default provides an HTTP interface running by default on TCP
port 28017 which provides the “home” status page. This provides a vast
amount of information and the interface is not recommended for
production environments.
