### PR TITLE
Pin our version of mongodb

### DIFF
--- a/hieradata/role-mongo.yaml
+++ b/hieradata/role-mongo.yaml
@@ -5,6 +5,7 @@ classes:
 
 performanceplatform::mongo::data_dir: '/var/lib/mongodb'
 performanceplatform::mongo::disk_mount: '/dev/mapper/data-mongo'
+performanceplatform::mongo::version: '2.4.11'
 
 ufw_rules:
   allowmongo:

--- a/modules/performanceplatform/manifests/mongo.pp
+++ b/modules/performanceplatform/manifests/mongo.pp
@@ -7,12 +7,15 @@ class performanceplatform::mongo (
     $disk_mount = undef,
     $mongo_hosts,
     $require_logshipper = true,
+    $version = undef,
 ){
     if $require_logshipper {
       $before = [Lumberjack::Logshipper['mongo']]
     } else {
       $before = []
     }
+
+    validate_string($version)
 
     class { 'mongodb':
         enable_10gen    => true,
@@ -21,6 +24,7 @@ class performanceplatform::mongo (
         dbpath          => $data_dir,
         before          => $before,
         nohttpinterface => true,
+        version         => $version,
     }
 
 


### PR DESCRIPTION
We recently reprovisioned our mongo machines, and by a happy accident
upgraded to a more recent version.

This change explicitly controls which version we’re using, so that it if
we add more nodes, they will all be running the  same version until we
choose to upgrade.
