### PR TITLE
Disk growth check

### DIFF
--- a/modules/performanceplatform/manifests/checks/disk.pp
+++ b/modules/performanceplatform/manifests/checks/disk.pp
@@ -23,4 +23,14 @@ define performanceplatform::checks::disk (
     interval => 60,
     handlers => ['default'],
   }
+
+  # hopefully will alert when the disk growth rate for the last hour is over
+  # 10G, warn when over 5G - may need tuning if it becomes noisy
+  performanceplatform::checks::graphite { "check_disk_growth_${graphite_fqdn}_${graphite_disk}":
+    target   => "derivative(scaleToSeconds(collectd.${graphite_fqdn}.df${graphite_disk}.df_complex-free,3600))",
+    warning  => '5000000000', # 5 gig
+    critical => '10000000000',  # 10 gig
+    interval => 60,
+    handlers => ['default'],
+  }
 }


### PR DESCRIPTION
This should check the disk growth over the last hour, and alert if it is
more than 10G and warn if more than 5. Prompted by the issues we have
been having with elasticsearch filling the disk, as it happens too
quickly for a standard disk space alert to happen
