### PR TITLE
Use Azul Zulu JDK rather than Oracle

### DIFF
--- a/modules/java7/manifests/init.pp
+++ b/modules/java7/manifests/init.pp
@@ -1,28 +1,5 @@
 class java7 ($download_url) {
-  # Agree to the Oracle license agreement, so that we can install Java 7, so
-  # that we can install ElasticSearch
-
-  $download_dir= '/var/cache/oracle-jdk7-installer'
-  file {$download_dir:
-    ensure => directory,
-  }
-
-  exec { 'download-oracle-java7':
-    command => "/usr/bin/curl -o jdk-7u9-linux-x64.tar.gz ${download_url}",
-    cwd     => '/var/cache/oracle-jdk7-installer',
-    require => [Package['curl'], File[$download_dir]],
-    timeout => 3600,
-    unless  => '/usr/bin/test "`shasum -a 256 jdk-7u9-linux-x64.tar.gz`" = "1b39fe2a3a45b29ce89e10e59be9fbb671fb86c13402e29593ed83e0b419c8d7  jdk-7u9-linux-x64.tar.gz"',
-  }
-  notify{"command => /usr/bin/curl -o jdk-7u9-linux-x64.tar.gz ${download_url}":}
-  exec {
-    'set-licence-selected':
-      command => '/bin/echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections';
-    'set-licence-seen':
-      command => '/bin/echo debconf shared/accepted-oracle-license-v1-1 seen true | /usr/bin/debconf-set-selections';
-  }
-  package { 'oracle-java7-installer':
-    ensure  => present,
-    require => [Exec['set-licence-selected'], Exec['set-licence-seen'], Exec['download-oracle-java7']],
+  package { 'zulu-8':
+    ensure => installed,
   }
 }


### PR DESCRIPTION
This is an upgrade from 

```
java version "1.7.0_09"
Java(TM) SE Runtime Environment (build 1.7.0_09-b05)
Java HotSpot(TM) 64-Bit Server VM (build 23.5-b02, mixed mode)
```

to

```
openjdk version "1.8.0_20"
OpenJDK Runtime Environment (Zulu 8.3.0.1-linux64) (build 1.8.0_20-b26)
OpenJDK 64-Bit Server VM (Zulu 8.3.0.1-linux64) (build 25.20-b23, mixed mode)
```

As a member of the technical community in GDS,
I would like to understand my options when it comes to choosing
technology
So that I can make the best choice for my context

Typically, that involves experience and data. I’ve volunteered us to try
the Azul OpenJDK port for maturity and stability in production.

Exciting, eh?
