### PR TITLE
Add logic around vmware specific clause

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -132,13 +132,15 @@ Vagrant.configure("2") do |config|
         f.vmx["displayName"] = host[:name]
         if host[:extra_disk]
           vdiskmanager = '/Applications/VMware\ Fusion.app/Contents/Library/vmware-vdiskmanager'
-          file_to_disk =  "./tmp/#{host[:name]}-extra-disk.vmdk"
-          unless File.exists? file_to_disk
-            `#{vdiskmanager} -c -s 512MB -a lsilogic -t 1 #{file_to_disk}`
+          if File.exists?(vdiskmanager) && !File.exists?(file_to_disk)
+            file_to_disk =  "./tmp/#{host[:name]}-extra-disk.vmdk"
+            unless File.exists? file_to_disk
+              `#{vdiskmanager} -c -s 512MB -a lsilogic -t 1 #{file_to_disk}`
+            end
+            f.vmx['scsi0:1.filename'] = File.dirname(__FILE__) + "/" + file_to_disk
+            f.vmx['scsi0:1.present']  = 'TRUE'
+            f.vmx['scsi0:1.redo']     = ''
           end
-          f.vmx['scsi0:1.filename'] = File.dirname(__FILE__) + "/" + file_to_disk
-          f.vmx['scsi0:1.present']  = 'TRUE'
-          f.vmx['scsi0:1.redo']     = ''
         end
       end
 


### PR DESCRIPTION
- Really temporary fix for suckers in the team who aren't lucky enough to have :money_with_wings: vmware :money_with_wings: as their vm provider
- It's difficult to switch on current provider in your vagrantfile, there are some workarounds listed here: https://github.com/mitchellh/vagrant/issues/1867
- Will have a bash at refactoring to match some of those solutions, but this temporarily fixes this issue: ![](http://cl.ly/image/0n0m0E1F3b2y/Screen%20Shot%202014-10-24%20at%2012.57.47.png)
