### PR TITLE
Feature/new elasticsearch

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -3,6 +3,7 @@ forge "https://forgeapi.puppetlabs.com"
 mod 'attachmentgenie/ssh',        '1.2.2'
 mod 'attachmentgenie/ufw',        '1.2.0'
 mod 'dwerder/graphite',           '3.0.1'
+mod 'elasticsearch/elasticsearch','0.4.0'
 mod 'gdsoperations/openconnect'
 mod 'jfryman/nginx',              '0.0.9'
 mod 'puppetlabs/apt',             '1.4.2'
@@ -28,8 +29,6 @@ mod 'alphagov/collectd',            :git => 'https://github.com/alphagov/puppet-
                                     :ref => 'improve_collectd_varnish'
 mod 'alphagov/curl',                :git => 'https://github.com/alphagov/puppet-curl.git',
                                     :ref => 'f4c6d175bdc6cbd71f71fbaa2544ef8f70c4ce48'
-mod 'gds/elasticsearch',            :git => 'https://github.com/gds-operations/puppet-elasticsearch.git',
-                                    :ref => 'd15521e6cb215a809d92692e76a1d0cac111d9a0'
 mod 'alphagov/ext4mount',           :git => 'https://github.com/alphagov/puppet-ext4mount.git',
                                     :ref => 'd97f99cc2801b83152b905d1285fa34e689cb499'
 mod 'alphagov/gstatsd',             :git => 'https://github.com/alphagov/puppet-gstatsd.git',

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -7,9 +7,11 @@ FORGE
       puppetlabs-stdlib (>= 2.2.1)
     dwerder-graphite (3.0.1)
       puppetlabs-stdlib (>= 2.2.1)
+    elasticsearch-elasticsearch (0.4.0)
+      puppetlabs-stdlib (>= 3.2.0)
     example42-monitor (2.0.1)
       example42-puppi (>= 2.0.0)
-    example42-puppi (2.1.9)
+    example42-puppi (2.1.10)
     garethr-erlang (0.3.0)
       puppetlabs-apt (>= 0)
       puppetlabs-stdlib (>= 0)
@@ -20,7 +22,7 @@ FORGE
       puppetlabs-apt (>= 1.0.0)
       puppetlabs-concat (>= 1.0.0)
       puppetlabs-stdlib (>= 0.1.6)
-    maestrodev-wget (1.5.1)
+    maestrodev-wget (1.5.6)
     netmanagers-fail2ban (1.4.0)
       example42-monitor (>= 2.0.0)
       example42-puppi (>= 2.0.0)
@@ -28,8 +30,8 @@ FORGE
       puppetlabs-stdlib (>= 4.1.0)
     puppetlabs-apt (1.4.2)
       puppetlabs-stdlib (>= 2.2.1)
-    puppetlabs-concat (1.1.0)
-      puppetlabs-stdlib (>= 4.0.0)
+    puppetlabs-concat (1.1.1)
+      puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
     puppetlabs-firewall (1.1.3)
     puppetlabs-gcc (0.0.3)
     puppetlabs-nodejs (0.4.0)
@@ -54,7 +56,7 @@ FORGE
     sensu-sensu (0.7.7)
       puppetlabs-apt (>= 0.0.1)
       puppetlabs-stdlib (>= 0.0.1)
-    stahnma-epel (0.1.1)
+    stahnma-epel (1.0.0)
 
 GIT
   remote: https://github.com/alphagov/puppet-account.git
@@ -172,14 +174,6 @@ GIT
     endore-me-tmux (0.0.1)
 
 GIT
-  remote: https://github.com/gds-operations/puppet-elasticsearch.git
-  ref: d15521e6cb215a809d92692e76a1d0cac111d9a0
-  sha: d15521e6cb215a809d92692e76a1d0cac111d9a0
-  specs:
-    gds-elasticsearch (0.0.1)
-      puppetlabs-stdlib (>= 3.0.0)
-
-GIT
   remote: https://github.com/gini/puppet-archive.git
   ref: 50d3370006f955ee9d5187623cc660670d01c58d
   sha: 50d3370006f955ee9d5187623cc660670d01c58d
@@ -218,8 +212,8 @@ DEPENDENCIES
   attachmentgenie-ufw (= 1.2.0)
   bison-upstart (>= 0)
   dwerder-graphite (= 3.0.1)
+  elasticsearch-elasticsearch (= 0.4.0)
   endore-me-tmux (>= 0)
-  gds-elasticsearch (>= 0)
   gdsoperations-openconnect (>= 0)
   gini-archive (>= 0)
   jfryman-nginx (= 0.0.9)

--- a/hieradata/role-jumpbox.yaml
+++ b/hieradata/role-jumpbox.yaml
@@ -42,7 +42,7 @@ performanceplatform::jenkins::plugin_hash:
         version: "1.8"
 
 performanceplatform::kibana::elasticsearch_url: "https://%{::elasticsearch_vhost}"
-performanceplatform::kibana::tarball_url: 'https://download.elasticsearch.org/kibana/kibana/kibana-3.0.0milestone4.tar.gz'
+performanceplatform::kibana::version: '3.1.1'
 
 
 python::version:    '2.7'

--- a/hieradata/role-logs-elasticsearch.yaml
+++ b/hieradata/role-logs-elasticsearch.yaml
@@ -10,6 +10,7 @@ performanceplatform::elasticsearch::disk_mount: '/dev/mapper/data-elasticsearch'
 performanceplatform::elasticsearch::cluster_hosts:
   - 'logs-elasticsearch-1:9300'
   - 'logs-elasticsearch-2:9300'
+  - 'logs-elasticsearch-3:9300'
 performanceplatform::elasticsearch::minimum_master_nodes: '1'
 
 

--- a/modules/performanceplatform/files/elasticsearch/logging.yml
+++ b/modules/performanceplatform/files/elasticsearch/logging.yml
@@ -1,0 +1,61 @@
+# This file is managed by Puppet, do not edit manually, your changes *will* be overwritten!
+#
+# Please see the source file for context and more information:
+#
+# https://github.com/elasticsearch/elasticsearch/blob/master/config/logging.yml
+#
+
+es.logger.level: INFO
+rootLogger: INFO, console, file
+
+# ----- Configuration set by Puppet ---------------------------------------------
+
+
+logger.action: DEBUG
+
+logger.com.amazonaws: WARN
+
+logger.index.indexing.slowlog: TRACE, index_indexing_slow_log_file
+
+logger.index.search.slowlog: TRACE, index_search_slow_log_file
+
+
+# -------------------------------------------------------------------------------
+
+additivity:
+  index.search.slowlog: false
+  index.indexing.slowlog: false
+
+appender:
+  console:
+    type: console
+    layout:
+      type: consolePattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  file:
+    type: rollingFile
+    file: ${path.logs}/${cluster.name}.log
+    maxFileSize: 100000000
+    maxBackupIndex: 10
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  index_search_slow_log_file:
+    type: rollingFile
+    file: ${path.logs}/${cluster.name}_index_search_slowlog.log
+    maxFileSize: 100000000
+    maxBackupIndex: 10
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  index_indexing_slow_log_file:
+    type: rollingFile
+    file: ${path.logs}/${cluster.name}_index_indexing_slowlog.log
+    maxFileSize: 100000000
+    maxBackupIndex: 10
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"

--- a/modules/performanceplatform/files/elasticsearch/wildcard.template.json
+++ b/modules/performanceplatform/files/elasticsearch/wildcard.template.json
@@ -1,0 +1,60 @@
+{
+    "mappings": {
+        "_default_": {
+            "_all": {
+                "enabled": false
+            },
+            "properties": {
+                "@fields": {
+                    "dynamic": true,
+                    "path": "full",
+                    "properties": {
+                        "args": {
+                            "type": "string"
+                        },
+                        "request_time": {
+                            "type": "double"
+                        }
+                    },
+                    "type": "object"
+                },
+                "@message": {
+                    "index": "analyzed",
+                    "type": "string"
+                },
+                "@source": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "@source_host": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "@source_path": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "@tags": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "@timestamp": {
+                    "index": "not_analyzed",
+                    "type": "date"
+                },
+                "@type": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "order": 0,
+    "settings": {
+        "index.cache.field.type": "soft",
+        "index.query.default_field": "@message",
+        "index.refresh_interval": "10s",
+        "index.store.compress.stored": "true"
+    },
+    "template": "*"
+}

--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -20,9 +20,6 @@ class performanceplatform::elasticsearch(
     fqdn => $::fqdn,
     disk => $data_dir,
   }
-  logrotate::rule { 'elasticsearch-rotate':
-    ensure => absent,
-  }
 
   lvm::volume { 'elasticsearch':
     ensure => 'present',

--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -29,6 +29,12 @@ class performanceplatform::elasticsearch(
     before => Performanceplatform::Mount[$data_dir]
   }
 
+  package { 'estools':
+    ensure   => '1.1.2',
+    provider => 'pip',
+    require  => Package['python-pip'],
+  }
+
   cron {'elasticsearch-rotate-indices':
     ensure  => present,
     user    => 'nobody',

--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -42,7 +42,7 @@ class performanceplatform::elasticsearch(
   }
 
   sensu::check { 'elasticsearch_is_out_of_memory':
-    command  => '/etc/sensu/community-plugins/plugins/files/check-tail.rb -f /var/log/elasticsearch/elasticsearch.log -l 50 -P OutOfMemory',
+    command  => '/etc/sensu/community-plugins/plugins/files/check-tail.rb -f /var/log/elasticsearch/logs/elasticsearch.log -l 50 -P OutOfMemory',
     interval => 60,
     handlers => ['default'],
   }

--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -58,7 +58,7 @@ class performanceplatform::elasticsearch(
   }
 
   apt::source { 'elasticsearch':
-    location    => "http://packages.elasticsearch.org/elasticsearch/1.3/debian",
+    location    => 'http://packages.elasticsearch.org/elasticsearch/1.3/debian',
     release     => 'stable',
     repos       => 'main',
     key         => 'D88E42B4',
@@ -67,20 +67,20 @@ class performanceplatform::elasticsearch(
   }
 
   class { '::elasticsearch':
-    version      => '1.3.4',
-    datadir      => $data_dir,
-    config       => {},
-    require      => [Performanceplatform::Mount[$data_dir], Class['java'], Apt::Source['elasticsearch']],
+    version => '1.3.4',
+    datadir => $data_dir,
+    config  => {},
+    require => [Performanceplatform::Mount[$data_dir], Class['java'], Apt::Source['elasticsearch']],
   }
 
   ::elasticsearch::instance { 'logs':
-    config => {
-      'bootstrap.mlockall' => false,
-      'cluster.name'       => 'elasticsearch',
-      'discovery'          => {
+    config        => {
+      'bootstrap.mlockall'       => false,
+      'cluster.name'             => 'elasticsearch',
+      'discovery'                => {
         'zen' => {
           'minimum_master_nodes' => $minimum_master_nodes,
-          'ping' => {
+          'ping'                 => {
             'multicast.enabled' => false,
             'unicast.hosts'     => $cluster_hosts,
           }
@@ -95,6 +95,7 @@ class performanceplatform::elasticsearch(
     init_defaults => {
       'ES_HEAP_SIZE' => $heap_size,
     },
+    logging_file  => 'puppet:///modules/performanceplatform/elasticsearch/logging.yml',
   }
 
   ::elasticsearch::plugin { 'mobz/elasticsearch-head':

--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -6,16 +6,6 @@ class performanceplatform::elasticsearch(
   $heap_size,
 ) {
 
-  class { '::elasticsearch':
-    cluster_hosts        => $cluster_hosts,
-    data_directory       => $data_dir,
-    host                 => $::hostname,
-    heap_size            => $heap_size,
-    minimum_master_nodes => $minimum_master_nodes,
-    require              => [Performanceplatform::Mount[$data_dir], Class['java']]
-  }
-
-
   file { '/mnt/data':
     ensure => directory,
   }
@@ -25,73 +15,6 @@ class performanceplatform::elasticsearch(
     disk         => $disk_mount,
     require      => File['/mnt/data'],
   }
-
-
-  cron {'elasticsearch-rotate-indices':
-    ensure  => present,
-    user    => 'nobody',
-    hour    => '0',
-    minute  => '1',
-    command => '/usr/local/bin/es-rotate --delete-old --delete-maxage 21 logstash',
-    require => Class['::elasticsearch'],
-  }
-
-  elasticsearch::plugin { 'head':
-    install_from => 'mobz/elasticsearch-head',
-  }
-
-  elasticsearch::template { 'wildcard':
-    content =>  '{
-      "template": "*",
-      "order": 0,
-      "settings": {
-        "index.query.default_field":    "@message",
-        "index.store.compress.stored":  "true",
-        "index.cache.field.type":       "soft",
-        "index.refresh_interval":       "10s"
-      },
-      "mappings": {
-        "_default_": {
-          "_all": {
-            "enabled": false
-          },
-          "properties": {
-            "@fields": {
-              "path": "full",
-              "dynamic": true,
-              "properties": {
-                "args": {"type": "string"},
-                "request_time": {"type": "double"}
-              },
-              "type": "object"
-            },
-            "@message":     { "index": "analyzed",     "type": "string" },
-            "@source":      { "index": "not_analyzed", "type": "string" },
-            "@source_host": { "index": "not_analyzed", "type": "string" },
-            "@source_path": { "index": "not_analyzed", "type": "string" },
-            "@tags":        { "index": "not_analyzed", "type": "string" },
-            "@timestamp":   { "index": "not_analyzed", "type": "date"   },
-            "@type":        { "index": "not_analyzed", "type": "string" }
-          }
-        }
-      }
-    }'
-  }
-
-  sensu::check { 'elasticsearch_is_out_of_memory':
-    command  => '/etc/sensu/community-plugins/plugins/files/check-tail.rb -f /var/log/elasticsearch/elasticsearch.log -l 50 -P OutOfMemory',
-    interval => 60,
-    handlers => ['default'],
-  }
-
-  sensu::check { 'elasticsearch_cluster_status':
-    command  => '/etc/sensu/community-plugins/plugins/elasticsearch/check-es-cluster-status.rb',
-    interval => 60,
-    handlers => ['default'],
-    require  => Package['rest-client'],
-  }
-
-  $graphite_fqdn = regsubst($::fqdn, '\.', '_', 'G')
 
   performanceplatform::checks::disk { "${::fqdn}_${data_dir}":
     fqdn => $::fqdn,
@@ -107,6 +30,78 @@ class performanceplatform::elasticsearch(
     pv     => '/dev/sdb1',
     fstype => 'ext4',
     before => Performanceplatform::Mount[$data_dir]
+  }
+
+  cron {'elasticsearch-rotate-indices':
+    ensure  => present,
+    user    => 'nobody',
+    hour    => '0',
+    minute  => '1',
+    command => '/usr/local/bin/es-rotate --delete-old --delete-maxage 21 logstash',
+    require => Class['::elasticsearch'],
+  }
+
+  sensu::check { 'elasticsearch_is_out_of_memory':
+    command  => '/etc/sensu/community-plugins/plugins/files/check-tail.rb -f /var/log/elasticsearch/elasticsearch.log -l 50 -P OutOfMemory',
+    interval => 60,
+    handlers => ['default'],
+  }
+
+  sensu::check { 'elasticsearch_cluster_status':
+    command  => '/etc/sensu/community-plugins/plugins/elasticsearch/check-es-cluster-status.rb',
+    interval => 60,
+    handlers => ['default'],
+    require  => Package['rest-client'],
+  }
+
+  apt::source { 'elasticsearch':
+    location    => "http://packages.elasticsearch.org/elasticsearch/1.3/debian",
+    release     => 'stable',
+    repos       => 'main',
+    key         => 'D88E42B4',
+    key_source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
+    include_src => false,
+  }
+
+  class { '::elasticsearch':
+    version      => '1.3.4',
+    datadir      => $data_dir,
+    config       => {},
+    require      => [Performanceplatform::Mount[$data_dir], Class['java'], Apt::Source['elasticsearch']],
+  }
+
+  ::elasticsearch::instance { 'logs':
+    config => {
+      'bootstrap.mlockall' => false,
+      'cluster.name'       => 'elasticsearch',
+      'discovery'          => {
+        'zen' => {
+          'minimum_master_nodes' => $minimum_master_nodes,
+          'ping' => {
+            'multicast.enabled' => false,
+            'unicast.hosts'     => $cluster_hosts,
+          }
+        }
+      },
+      'index.number_of_replicas' => 1,
+      'index.number_of_shards'   => 5,
+      'index.refresh_interval'   => '1s',
+      'network.publish_host'     => $::hostname,
+      'node.name'                => $::hostname,
+    },
+    init_defaults => {
+      'ES_HEAP_SIZE' => $heap_size,
+    },
+  }
+
+  ::elasticsearch::plugin { 'mobz/elasticsearch-head':
+    module_dir => 'head',
+    instances  => 'logs',
+  }
+
+  ::elasticsearch::template { 'wildcard':
+    file    => 'puppet:///modules/performanceplatform/elasticsearch/wildcard.template.json',
+    require => Elasticsearch::Instance['logs'],
   }
 
 }

--- a/modules/performanceplatform/templates/kibana.config.js.erb
+++ b/modules/performanceplatform/templates/kibana.config.js.erb
@@ -35,20 +35,19 @@ function (Settings) {
     panel_names: [
       'histogram',
       'map',
-      'pie',
+      'goal',
       'table',
       'filtering',
       'timepicker',
       'text',
-      'fields',
       'hits',
-      'dashcontrol',
       'column',
-      'derivequeries',
       'trends',
       'bettermap',
       'query',
-      'terms'
+      'terms',
+      'stats',
+      'sparklines'
     ]
   });
 });

--- a/tools/bootstrap-vagrant
+++ b/tools/bootstrap-vagrant
@@ -28,7 +28,7 @@ set_dns_server() {
 
 check_ruby() {
   echo "--> Check for Ruby" | pp
-  for package in ruby1.9.1{,-dev}; do
+  for package in ruby1.9.1{,-dev} libaugeas-ruby1.9.1; do
     if ! dpkg -s $package >/dev/null 2>&1; then
       apt-get update -qq
       apt-get install -qq $package 2>&1 | pp


### PR DESCRIPTION
Upgrades elasticsearch to 1.3.4, kibana and fixes estools and log rotation.

Kibana needed to be upgrade because the old version we were using didn't support the new version of elasticsearch.
