### PR TITLE
Improve puppet logging

### DIFF
--- a/tools/puppet-apply
+++ b/tools/puppet-apply
@@ -2,6 +2,13 @@
 set -eu
 
 cd "$(dirname $0)/.."
+LOGFILE=/vagrant/puppet.log
+if [ -e $LOGFILE ]; then
+  rm $LOGFILE
+fi
 exec ./bin/puppet apply --modulepath=modules:vendor/modules \
                         --hiera_config=hiera.yaml \
+			--logdest=console \
+			--logdest=$LOGFILE \
+			--verbose \
                         manifests


### PR DESCRIPTION
- Log to a file as well as the console. Useful for grepping for errors
  rather than having to scrollback through terminal. File is deleted at
  start so it doesn't grow for ever
  - Add the verbose switch to give some more useful information, but not
    as much information overload as debug mode gives
