### PR TITLE
Add a disk check to the backup box

### DIFF
--- a/modules/performanceplatform/manifests/backup_box.pp
+++ b/modules/performanceplatform/manifests/backup_box.pp
@@ -31,6 +31,11 @@ class performanceplatform::backup_box(
         require      => File['/mnt/data'],
     }
 
+    performanceplatform::checks::disk { "${::fqdn}_${backup_dir}":
+        fqdn => $::fqdn,
+        disk => $backup_dir,
+    }
+
     file { "${backup_dir}/postgresql":
         ensure  => directory,
         owner   => 'deploy',


### PR DESCRIPTION
We weren't checking whether the data mount on the backup box had free disk space. We will now have an alert for that.
