### PR TITLE
Add hyphens to fix `df` disk checks

### DIFF
--- a/modules/performanceplatform/manifests/checks/disk.pp
+++ b/modules/performanceplatform/manifests/checks/disk.pp
@@ -6,7 +6,7 @@ define performanceplatform::checks::disk (
   $graphite_disk = regsubst(regsubst($disk, '^/', ''), '/', '-', 'G')
 
   performanceplatform::checks::graphite { "check_low_disk_space_${graphite_fqdn}_${graphite_disk}":
-    target   => "collectd.${graphite_fqdn}.df${graphite_disk}.df_complex-free",
+    target   => "collectd.${graphite_fqdn}.df-${graphite_disk}.df_complex-free",
     warning  => '4000000000', # A little less than 4 gig
     critical => '1000000000',  # A little less than 1 gig
     below    => true,
@@ -16,7 +16,7 @@ define performanceplatform::checks::disk (
 
 
   performanceplatform::checks::graphite { "check_low_disk_inodes_${graphite_fqdn}_${graphite_disk}":
-    target   => "collectd.${graphite_fqdn}.df${graphite_disk}.df_inodes-free",
+    target   => "collectd.${graphite_fqdn}.df-${graphite_disk}.df_inodes-free",
     warning  => '500000',
     critical => '100000',
     below    => true,
@@ -27,7 +27,7 @@ define performanceplatform::checks::disk (
   # hopefully will alert when the disk growth rate for the last hour is over
   # 10G, warn when over 5G - may need tuning if it becomes noisy
   performanceplatform::checks::graphite { "check_disk_growth_${graphite_fqdn}_${graphite_disk}":
-    target   => "derivative(scaleToSeconds(collectd.${graphite_fqdn}.df${graphite_disk}.df_complex-free,3600))",
+    target   => "derivative(scaleToSeconds(collectd.${graphite_fqdn}.df-${graphite_disk}.df_complex-free,3600))",
     warning  => '5000000000', # 5 gig
     critical => '10000000000',  # 10 gig
     interval => 60,


### PR DESCRIPTION
These hyphens do not exist, which means that we're requesting collectd
data like:

```
dfmnt-data-elasticsearch
```

This doesn't work, we should instead be looking for:

```
df-mnt-data-elasticsearch
```
