### PR TITLE
Fix DNS lookups for internal services

### DIFF
--- a/modules/performanceplatform/templates/internal-dns.erb
+++ b/modules/performanceplatform/templates/internal-dns.erb
@@ -3,9 +3,9 @@
 domain-needed
 bogus-priv
 cache-size=15000
-local=/internal/
+local=/localdomain/
 expand-hosts
-domain=internal
+domain=localdomain
 no-negcache
 strict-order
 


### PR DESCRIPTION
We are doing lots of external DNS lookups for graphite.localdomain. We
should stop doing that.
