### PR TITLE
Explicitly choose our allowed SSH ciphers

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,6 +1,6 @@
 forge "https://forgeapi.puppetlabs.com"
 
-mod 'attachmentgenie/ssh',        '1.2.2'
+mod 'attachmentgenie/ssh',        '1.4.1'
 mod 'attachmentgenie/ufw',        '1.2.0'
 mod 'dwerder/graphite',           '3.0.1'
 mod 'elasticsearch/elasticsearch','0.4.0'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,7 +1,7 @@
 FORGE
   remote: https://forgeapi.puppetlabs.com
   specs:
-    attachmentgenie-ssh (1.2.2)
+    attachmentgenie-ssh (1.4.1)
       puppetlabs-stdlib (>= 2.2.1)
     attachmentgenie-ufw (1.2.0)
       puppetlabs-stdlib (>= 2.2.1)
@@ -212,7 +212,7 @@ DEPENDENCIES
   alphagov-lumberjack (>= 0)
   alphagov-mongodb (>= 0)
   alphagov-redis (>= 0)
-  attachmentgenie-ssh (= 1.2.2)
+  attachmentgenie-ssh (= 1.4.1)
   attachmentgenie-ufw (= 1.2.0)
   bison-upstart (>= 0)
   dwerder-graphite (= 3.0.1)

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -139,6 +139,11 @@ sensu::rabbitmq_port: 5672
 sensu::safe_mode: true
 sensu::version: '0.12.1-1'
 
+ssh::server::ciphers:
+  - aes128-ctr
+  - aes192-ctr
+  - aes256-ctr
+
 lumberjack::hosts:
   - 'logstash:3456'
 lumberjack::deb_source:  'puppet:///modules/performanceplatform/lumberjack_0.2.0_amd64.deb'


### PR DESCRIPTION
The symmetric portion of the SSH Transport Protocol (as described in RFC
4253 [1]) has security weaknesses that allowed recovery of up to 32 bits of
plaintext from a block of ciphertext that was encrypted with the Cipher
Block Chaining (CBD) method. New Counter mode algorithms (as described in
RFC4344 [2]) were designed that are not vulnerable to these types of
attacks and these algorithms are now recommended for standard use.

[1] https://tools.ietf.org/html/rfc4253
[2] https://tools.ietf.org/html/rfc4344
