### PR TITLE
Add tcpdump to all machines

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -249,6 +249,7 @@ system_packages:
   - ssl-cert
   - strace
   - sysstat
+  - tcpdump
   - update-notifier
   - vim
 


### PR DESCRIPTION
Because it useful when we are diagnosing network issues.
