### PR TITLE
Add default param for development mode

### DIFF
--- a/modules/performanceplatform/manifests/assets.pp
+++ b/modules/performanceplatform/manifests/assets.pp
@@ -9,7 +9,7 @@ class performanceplatform::assets (
   $ssl_path = hiera('ssl_path')
   $ssl_cert = hiera('public_ssl_cert')
   $ssl_key = hiera('public_ssl_key')
-  $ssl_dhparam = hiera('ssl_dhparam')
+  $ssl_dhparam = hiera('ssl_dhparam', 'private/ssl-dhparam.pem')
 
   nginx::resource::vhost { $::assets_internal_vhost:
     ssl                 => true,

--- a/modules/performanceplatform/manifests/kibana.pp
+++ b/modules/performanceplatform/manifests/kibana.pp
@@ -26,7 +26,7 @@ class performanceplatform::kibana(
   $ssl_path = hiera('ssl_path')
   $ssl_cert = hiera('environment_ssl_cert')
   $ssl_key = hiera('environment_ssl_key')
-  $ssl_dhparam = hiera('ssl_dhparam')
+  $ssl_dhparam = hiera('ssl_dhparam', 'private/ssl-dhparam.pem')
 
   nginx::resource::vhost { $::kibana_vhost:
     ssl         => true,


### PR DESCRIPTION
We dont have a dhparam pem in development in pp-deployment, so trying to
provision machines through vagrant fails (frontend-app-1 being the
example tried).
