### PR TITLE
Explicitly configure the ciphers that we use

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -179,6 +179,8 @@ nameservers:
   - 8.8.8.8
   - 8.8.4.4
 
+nginx::resource::vhost::ssl_ciphers: 'EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:EECDH+RC4:RSA+RC4:!MD5;'
+
 ntp::servers:
   - 'ntp.ubuntu.com'
   - 'time.euro.apple.com'


### PR DESCRIPTION
The default is `HIGH:!aNULL:!MD5;`. That gives us quite a few potential
ciphers (~64 on current server configuration).

We don’t support SSLv3, so remove the associated ciphers and have 39
fewer ciphers being loaded.

We can also take https://github.com/cloudflare/sslconfig/blob/master/conf 
as a reasonable default for large parts of the internet. This should
still support Windows XP.
