### PR TITLE
Enable SPDY support

### DIFF
--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -179,6 +179,7 @@ define performanceplatform::proxy_vhost(
     listen_port           => $port,
     listen_options        => $listen_options,
     proxy                 => "http://${upstream_name}",
+    spdy                  => 'on',
     ssl                   => $ssl,
     ssl_port              => $ssl_port,
     ssl_protocols         => 'TLSv1 TLSv1.1 TLSv1.2',


### PR DESCRIPTION
SPDY works per domain. This means SPDY can reduce connections and
multiplex requests to a single domain. For instance, if we had a backing
service on a single domain that a frontend service was quite chatty to,
SPDY should be quite beneficial.

http://www.guypo.com/not-as-spdy-as-you-thought/

Do you see where I’m going with this? ;)
