### PR TITLE
Use location_cfg_append instead of try_files

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -138,11 +138,8 @@ vhost_proxies:
       big_screen_view:
         location: /big-screen
         location_alias: /opt/big_screen/current
-        try_files:
-          - '$uri'
-          - '$uri/'
-          - '/index.html'
-          - '=404'
+        location_cfg_append:
+          try_files: '$uri $uri/ /index.html =404'
 
   stagecraft-vhost:
     servername:    "%{::stagecraft_vhost}"


### PR DESCRIPTION
try_files only exists in the vhost_location_directory template, which is only used if you provide a www_root and not an alias.

Because Puppet modules, I guess?
