### PR TITLE
Change notifier job to use new entry point

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -32,7 +32,7 @@ performanceplatform::notifier::group: 'deploy'
 performanceplatform::notifier::cron_definition:
   'notifier-cron-job':
     minute: '0'
-    command: "cd %{hiera('performanceplatform::notifier::app_path')}/current && npm start"
+    command: "cd %{hiera('performanceplatform::notifier::app_path')}/current && npm run-script out-of-date"
   'notifier-summary-cron-job':
     # Send summary emails early on Monday mornings
     minute: 0


### PR DESCRIPTION
The notifier now also sends summary emails, so it doesn't make sense for `npm start` to do a single thing.

This needs to be merged and deployed at the same time as alphagov/performanceplatform-notifier#35.
