### PR TITLE
Fall back to latest virtualbox version if no box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,11 +53,17 @@ def get_box(provider)
     virtualBoxVersion = `vboxmanage --version`.strip
     box = $boxesByVersion[virtualBoxVersion]
     if box.nil?
-      $stderr.puts <<EOS
-Virtualbox version #{virtualBoxVersion} is not supported. See README.md.
+
+      error = <<EOS
+Virtualbox version #{virtualBoxVersion} is not supported. Falling back to latest virtualbox box. See README.md.
 Supported: #{$boxesByVersion.keys} --> #{$boxesByVersion.values.map {|item| item[:link]}}
 EOS
-      exit 1
+$stderr.puts error unless @warned
+    # Gem version to sort by version numbers, need to dup the string as it mutates
+    # max by returns an array, which we convert back into a hash
+    latest = $boxesByVersion.keys.max_by{|v| Gem::Version.new(v.dup)}
+    box = $boxesByVersion[latest]
+    @warned = true
     end
 
     name, url = box[:name], box[:url]


### PR DESCRIPTION
If no box has been built for the specific version of virtualbox used,
print a warning but fall back to using the latest available box.

This code gets executed when you have vmware installed, and would fail
to run the Vagrantfile. I have also tried with later versions of
virtualbox, and the box has worked even though the version doesnt
exactly match, so I think printing a warning is better behaviour than
bailing completely.
