### PR TITLE
Check which is specific to the agent only.

### DIFF
--- a/modules/performanceplatform/manifests/monitoring/logstash.pp
+++ b/modules/performanceplatform/manifests/monitoring/logstash.pp
@@ -43,7 +43,7 @@ class performanceplatform::monitoring::logstash (
   }
 
   sensu::check { 'logstash_is_down':
-    command  => '/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p logstash -C 1 -W 1',
+    command  => "/etc/sensu/community-plugins/plugins/processes/check-procs.rb -p 'logstash/runner.rb agent' -C 1 -W 1",
     interval => 60,
     handlers => ['default'],
   }


### PR DESCRIPTION
For some reason (memory according to Tim) logstash is going down and checks are not detecting this due to the logstash web process still running. This makes the check more specific to check the agent is up.

If we still want to check for the web we can bump the process count and
have the less specific check or we can create a separate check.
