### PR TITLE
Fix for no alerts even when logging drops to 0

### DIFF
--- a/modules/performanceplatform/manifests/checks/elasticsearch/index.pp
+++ b/modules/performanceplatform/manifests/checks/elasticsearch/index.pp
@@ -21,8 +21,8 @@ define performanceplatform::checks::elasticsearch::index(
   # the massive negative derivative (when rolling) causing the check to fire.
   performanceplatform::checks::graphite { $name:
     target   => "removeBelowValue(derivative(${graphite}),0)",
-    warning  => '0',
-    critical => '0',
+    warning  => '1',
+    critical => '1',
     below    => true,
     interval => 60,
     handlers => ['default'],


### PR DESCRIPTION
The ruby check uses < or > not >= or <=. Checking below not below zero
makes not sense.
