### PR TITLE
Only check logging rate in production.

### DIFF
--- a/modules/performanceplatform/manifests/checks/elasticsearch/logging.pp
+++ b/modules/performanceplatform/manifests/checks/elasticsearch/logging.pp
@@ -1,14 +1,17 @@
 class performanceplatform::checks::elasticsearch::logging(
 ) {
 
-  performanceplatform::checks::elasticsearch::index { 'check_lumberjack_logging_rate':
-    index => 'logstash-current',
-    type  => 'lumberjack',
-  }
+  
+  if $::pp_environment == 'production' {
+    performanceplatform::checks::elasticsearch::index { 'check_lumberjack_logging_rate':
+      index => 'logstash-current',
+      type  => 'lumberjack',
+    }
 
-  performanceplatform::checks::elasticsearch::index { 'check_syslog_logging_rate':
-    index => 'logstash-current',
-    type  => 'syslog',
+    performanceplatform::checks::elasticsearch::index { 'check_syslog_logging_rate':
+      index => 'logstash-current',
+      type  => 'syslog',
+    }
   }
 
 }


### PR DESCRIPTION
Currently logging rate is so low in preview (and most likely staging)
that it is constantly triggering a critical alert in those environments.

This allows us to deploy to staging without constant critical alerts. If
we find we need the log check back however, Tim has suggested adding a
heartbeat.
