### PR TITLE
Disable dynamic scripting on elasticsearch

### DIFF
--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -91,6 +91,7 @@ class performanceplatform::elasticsearch(
       'index.refresh_interval'   => '1s',
       'network.publish_host'     => $::hostname,
       'node.name'                => $::hostname,
+      'script.disable_dynamic'   => 'true'
     },
     init_defaults => {
       'ES_HEAP_SIZE' => $heap_size,


### PR DESCRIPTION
https://www.agileplannerapp.com/boards/47856/cards/7057

Prevent users from running arbitrary scripts via the API - this should
already be firewalled off, but disabling it is a good practice
