### PR TITLE
Fix check - fire if no new logs for 5 data points

### DIFF
--- a/modules/performanceplatform/manifests/checks/elasticsearch/index.pp
+++ b/modules/performanceplatform/manifests/checks/elasticsearch/index.pp
@@ -20,7 +20,7 @@ define performanceplatform::checks::elasticsearch::index(
   # the current index is rolled overnight. We use removeBelowValue to stop
   # the massive negative derivative (when rolling) causing the check to fire.
   performanceplatform::checks::graphite { $name:
-    target   => "removeBelowValue(derivative(${graphite}),0)",
+    target   => "removeBelowValue(movingAverage(derivative(${graphite}),5),0)",
     warning  => '1',
     critical => '1',
     below    => true,


### PR DESCRIPTION
As it stands logs are too bursty and the check frequency is too fine -
we are getting intermittent alerts due to no logs for a very short
period of time.

Do we definitely need the removebelowvalue? I understand about the switch overnight but this is brief and alerts about indexes decreasing in size normally could be useful?
