### PR TITLE
Set a less erratic threshold for logging

### DIFF
--- a/modules/performanceplatform/manifests/checks/elasticsearch/index.pp
+++ b/modules/performanceplatform/manifests/checks/elasticsearch/index.pp
@@ -20,7 +20,7 @@ define performanceplatform::checks::elasticsearch::index(
   # the current index is rolled overnight. We use removeBelowValue to stop
   # the massive negative derivative (when rolling) causing the check to fire.
   performanceplatform::checks::graphite { $name:
-    target   => "removeBelowValue(movingAverage(derivative(${graphite}),5),0)",
+    target   => "removeBelowValue(movingAverage(derivative(${graphite}),100),0)",
     warning  => '1',
     critical => '1',
     below    => true,


### PR DESCRIPTION
There must now be no new logs for 100 data points. In testing on
production this seems to cause an alert after around 3 minutes of logstash being turned off.
