### PR TITLE
Define datastore class for new API

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -8,6 +8,7 @@ classes:
   - 'performanceplatform::checks::stagecraft'
   - 'performanceplatform::checks::logstashforwarder'
   - 'performanceplatform::backdrop_smoke_tests'
+  - 'performanceplatform::datastore'
   - 'performanceplatform::notifier'
   - 'performanceplatform::pp_nginx'
   - 'performanceplatform::pip'
@@ -26,6 +27,9 @@ nginx::manage_repo: false
 nginx::package_ensure: '1.4.4-4~precise0'
 nginx::package_name: 'nginx-extras'
 nginx::server_tokens: 'off'
+
+performanceplatform::datastore::config_api_url: 'https://stagecraft.development.performance.service.gov.uk'
+performanceplatform::datastore::mongo_url: 'localhost:27017'
 
 performanceplatform::notifier::app_path: '/opt/performanceplatform-notifier'
 performanceplatform::notifier::user: 'deploy'

--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -3,6 +3,7 @@ classes:
   - 'clamav'
   - 'google_credentials'
   - 'nginx'
+  - 'performanceplatform::datastore'
   - 'performanceplatform::development'
   - 'performanceplatform::mongo'
   - 'performanceplatform::pp_nginx'
@@ -141,3 +142,6 @@ performanceplatform::development::stagecraft_password: "securem8"
 apt::always_apt_update: false
 performanceplatform::mongo::data_dir: '/var/lib/mongodb'
 performanceplatform::mongo::require_logshipper: false
+
+performanceplatform::datastore::config_api_url: 'https://stagecraft.development.performance.service.gov.uk'
+performanceplatform::datastore::mongo_url: 'localhost:27017'

--- a/modules/performanceplatform/manifests/datastore.pp
+++ b/modules/performanceplatform/manifests/datastore.pp
@@ -1,0 +1,29 @@
+#
+
+class performanceplatform::datastore(
+  $port = 3054,
+  $healthcheck = '/_status',
+  $app_module  = undef,
+  $user = undef,
+  $group = undef,
+  ) {
+  
+  performanceplatform::app { 'performance-datastore':
+    port                        => $port,
+    app_module                  => $app_module,
+    user                        => $user,
+    group                       => $group,
+    upstart_desc                => 'Datastore Job',
+    upstart_exec                => './performance-datastore',
+    proxy_append_forwarded_host => true,
+    proxy_set_forwarded_host    => false,
+    client_max_body_size        => '10m',
+    statsd_prefix               => 'datastore',
+    servername                  => 'datastore',
+    extra_env                   => {
+      'MONGO_URL'  => hiera('performanceplatform::datastore::mongo_url'),
+      'CONFIG_API_URL' => hiera('performanceplatform::datastore::config_api_url'),
+    },
+  }
+
+}


### PR DESCRIPTION
Spike around having a new Go backend API.

This will need DNS entries to make it visible, and probably a bit of iterating.
