### PR TITLE
Add Organisation API to backend-app role

### DIFF
--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -10,6 +10,7 @@ classes:
   - 'performanceplatform::backdrop_smoke_tests'
   - 'performanceplatform::datastore'
   - 'performanceplatform::notifier'
+  - 'performanceplatform::organisation_api'
   - 'performanceplatform::pp_nginx'
   - 'performanceplatform::pip'
   - 'performanceplatform::python_lxml_deps'

--- a/modules/performanceplatform/manifests/organisation_api.pp
+++ b/modules/performanceplatform/manifests/organisation_api.pp
@@ -1,0 +1,13 @@
+class performanceplatform::organisation_api (
+  $port = 3060,
+) {
+  
+  performanceplatform::app { 'organisation-api':
+    port                        => $port,
+    user                        => 'deploy',
+    group                       => 'deploy',
+    upstart_exec                => './organisation-api',
+    proxy_append_forwarded_host => true,
+  }
+
+}


### PR DESCRIPTION
We want to deploy the organisation api to our infrastructure, because it
would be useful to be able to use it.

It should exist on the backend machines as it is a supporting service of
the frontend applications.
