### PR TITLE
Make gunicorn app removable

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -148,6 +148,7 @@ ssh::server::ciphers:
   - aes192-ctr
   - aes256-ctr
 
+logstashforwarder::purge_configdir: true
 logstashforwarder::servers:
   - 'logstash:3456'
 logstashforwarder::ssl_ca: 'puppet:///modules/performanceplatform/logstash.pub'

--- a/modules/performanceplatform/manifests/gunicorn_app.pp
+++ b/modules/performanceplatform/manifests/gunicorn_app.pp
@@ -6,6 +6,7 @@
 #   to service a single external request
 #
 define performanceplatform::gunicorn_app (
+  $ensure                      = 'present',
   $description                 = $title,
   $port                        = undef,
   $workers                     = 4,
@@ -41,6 +42,7 @@ define performanceplatform::gunicorn_app (
   $virtualenv_path = "${app_path}/shared/venv"
 
   performanceplatform::proxy_vhost { "${title}-vhost":
+    ensure                      => $ensure,
     port                        => 80,
     upstream_port               => $port,
     servername                  => $servername,
@@ -67,18 +69,19 @@ define performanceplatform::gunicorn_app (
   }
 
   file { "${config_path}/gunicorn":
-    ensure  => present,
+    ensure  => $ensure,
     owner   => $user,
     group   => $group,
     content => template('performanceplatform/gunicorn.erb')
   }
   file { "${config_path}/gunicorn.logging.conf":
-    ensure  => present,
+    ensure  => $ensure,
     owner   => $user,
     group   => $group,
     content => template('performanceplatform/gunicorn.logging.conf.erb')
   }
   logrotate::rule { "${title}-application":
+    ensure       => $ensure,
     path         => "/opt/${title}/shared/log/*.log /opt/${title}/shared/log/*.log.json /var/log/${title}/*.log /var/log/${title}/*.log.json",
     rotate       => 30,
     rotate_every => 'day',

--- a/modules/performanceplatform/manifests/python_app.pp
+++ b/modules/performanceplatform/manifests/python_app.pp
@@ -1,4 +1,5 @@
 define performanceplatform::python_app (
+  $ensure          = 'present',
   $description     = $title,
   $app_path        = "/opt/${title}",
   $config_path     = "/etc/gds/${title}",
@@ -15,15 +16,22 @@ define performanceplatform::python_app (
 
   include upstart
 
+  if $ensure == 'present' {
+      $ensure_directory = 'directory'
+  }
+  else {
+      $ensure_directory = 'absent'
+  }
+
   file { [$app_path, "${app_path}/releases", "${app_path}/shared",
       "${app_path}/shared/log", "${app_path}/shared/assets", $config_path, $log_path]:
-    ensure => directory,
+    ensure => $ensure_directory,
     owner  => $user,
     group  => $group,
   }
 
   python::virtualenv { $virtualenv_path:
-    ensure     => present,
+    ensure     => $ensure,
     version    => '2.7',
     systempkgs => false,
     owner      => $user,
@@ -42,6 +50,7 @@ define performanceplatform::python_app (
   }
 
   upstart::job { $title:
+    ensure        => $ensure,
     description   => $upstart_desc,
     respawn       => true,
     respawn_limit => '5 10',


### PR DESCRIPTION
I think this should all work apart from logrotate file here:

https://github.com/alphagov/pp-puppet/blob/29f2b87f18527b60065109be4a5c6893a104afbb/modules/performanceplatform/manifests/python_app.pp#L64

Not quite sure what this does so I don't know if it needs removing explicitly. Seems to fill out a template?
