### PR TITLE
Alert when almost full boot partition on backup boxes

### DIFF
--- a/modules/performanceplatform/manifests/backup_box.pp
+++ b/modules/performanceplatform/manifests/backup_box.pp
@@ -36,6 +36,17 @@ class performanceplatform::backup_box(
         disk => $backup_dir,
     }
 
+    performanceplatform::checks::disk { "${::fqdn}_/boot":
+        fqdn                 => $::fqdn,
+        disk                 => '/boot',
+        disk_space_warning   => '300000000', # 300 MB (megabytes)
+        disk_space_critical  => '400000000',  # 400 MB (megabytes) out of 474 total
+        inodes_warning       => '80000',
+        inodes_critical      => '100000', #out of a total 124928
+        disk_growth_warning  => '50000000', # 50 MB (megabytes)
+        disk_growth_critical => '100000000',  # 100 MB (megabytes)
+    }
+
     file { "${backup_dir}/postgresql":
         ensure  => directory,
         owner   => 'deploy',

--- a/modules/performanceplatform/manifests/checks/disk.pp
+++ b/modules/performanceplatform/manifests/checks/disk.pp
@@ -1,14 +1,20 @@
 define performanceplatform::checks::disk (
-  $fqdn,
-  $disk,
+  $fqdn                 = undef,
+  $disk                 = undef,
+  $disk_space_warning   = '4000000000', # A little less than 4 gig
+  $disk_space_critical  = '1000000000', # A little less than 1 gig
+  $inodes_warning       = '500000',
+  $inodes_critical      = '100000',
+  $disk_growth_warning  = '5000000000', # 5 gig
+  $disk_growth_critical = '10000000000', # 10 gig
 ) {
   $graphite_fqdn = regsubst($fqdn, '\.', '_', 'G')
   $graphite_disk = regsubst(regsubst($disk, '^/', ''), '/', '-', 'G')
 
   performanceplatform::checks::graphite { "check_low_disk_space_${graphite_fqdn}_${graphite_disk}":
     target   => "collectd.${graphite_fqdn}.df-${graphite_disk}.df_complex-free",
-    warning  => '4000000000', # A little less than 4 gig
-    critical => '1000000000',  # A little less than 1 gig
+    warning  => $disk_space_warning,
+    critical => $disk_space_critical,
     below    => true,
     interval => 60,
     handlers => ['default'],
@@ -17,8 +23,8 @@ define performanceplatform::checks::disk (
 
   performanceplatform::checks::graphite { "check_low_disk_inodes_${graphite_fqdn}_${graphite_disk}":
     target   => "collectd.${graphite_fqdn}.df-${graphite_disk}.df_inodes-free",
-    warning  => '500000',
-    critical => '100000',
+    warning  => $inodes_warning,
+    critical => $inodes_critical,
     below    => true,
     interval => 60,
     handlers => ['default'],
@@ -29,8 +35,8 @@ define performanceplatform::checks::disk (
   performanceplatform::checks::graphite { "check_disk_growth_${graphite_fqdn}_${graphite_disk}":
     ensure   => absent,
     target   => "derivative(scaleToSeconds(collectd.${graphite_fqdn}.df-${graphite_disk}.df_complex-free,3600))",
-    warning  => '5000000000', # 5 gig
-    critical => '10000000000',  # 10 gig
+    warning  => $disk_growth_warning,
+    critical => $disk_growth_critical,
     interval => 60,
     handlers => ['default'],
   }


### PR DESCRIPTION
May be needed on other boxes but for now backup is the one which is
filling up with kernel updates (which we only saw due to side effects).

These numbers may be nuts. I asked a combination of df, wolfram alpha
and the df man pages but it's late on a friday and I'm tired!
