### PR TITLE
Move celery log level config into backend role

### DIFF
--- a/hieradata/environment.yaml
+++ b/hieradata/environment.yaml
@@ -45,7 +45,5 @@ pp_postgres::primary::stagecraft_password: "securem8"
 
 performanceplatform::pp_rabbitmq::transformer_password: 'notarealpw'
 
-performanceplatform::celery_worker::log_level: 'info'
-
 # Nginx configuration to restrict a vhost to the performance platform
 pp_only_vhost: ""

--- a/hieradata/role-backend-app.yaml
+++ b/hieradata/role-backend-app.yaml
@@ -116,3 +116,5 @@ logstashforwarder_files:
 ruby_packages:
   - curb
   - json
+
+performanceplatform::celery_worker::log_level: 'info'


### PR DESCRIPTION
environment.yaml is overwritten by pp-deployment, which does not contain
this key. Therefore hiera cannot find a value for the lookup, and writes
the init file with no value for loglevel which causes celery to fail.

We should re evaulate our hiera setup - this is a
confusing way for things to behave.
