### PR TITLE
Add a new physical volume to mongo machines

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -41,8 +41,7 @@ mod 'alphagov/jenkins',             :git => 'https://github.com/alphagov/puppet-
 mod 'elasticsearch/logstashforwarder',
                                     :git => 'https://github.com/elasticsearch/puppet-logstashforwarder.git',
                                     :ref => 'e07043db7c377da88d1d93b3ae967bf4b7f8dc32'
-mod 'puppetlabs/lvm',               :git => 'https://github.com/puppetlabs/puppetlabs-lvm.git',
-                                    :ref => 'ba8efdd243cafa96b45d8d58dbef1d5ba74714ea'
+mod 'puppetlabs/lvm',             '0.4.0'
 mod 'puppetlabs/rabbitmq',          :git => 'https://github.com/erhudy/puppetlabs-rabbitmq.git',
                                     :ref => '2f09f3a6a16291645e82daff5e0a22dbba137a22'
 mod 'alphagov/mongodb',             :git => 'https://github.com/alphagov/puppetlabs-mongodb.git',

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -35,6 +35,8 @@ FORGE
       puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
     puppetlabs-firewall (1.2.0)
     puppetlabs-gcc (0.0.3)
+    puppetlabs-lvm (0.4.0)
+      puppetlabs-stdlib (>= 4.1.0)
     puppetlabs-nodejs (0.4.0)
       puppetlabs-apt (>= 0.0.3)
       puppetlabs-stdlib (>= 2.0.0)
@@ -196,13 +198,6 @@ GIT
     gini-archive (0.1.1)
 
 GIT
-  remote: https://github.com/puppetlabs/puppetlabs-lvm.git
-  ref: ba8efdd243cafa96b45d8d58dbef1d5ba74714ea
-  sha: ba8efdd243cafa96b45d8d58dbef1d5ba74714ea
-  specs:
-    puppetlabs-lvm (0.1.2)
-
-GIT
   remote: https://github.com/stankevich/puppet-python.git
   ref: f508b71d534f3c67db12886fa914cb4ef74bbe7a
   sha: f508b71d534f3c67db12886fa914cb4ef74bbe7a
@@ -236,7 +231,7 @@ DEPENDENCIES
   netmanagers-fail2ban (= 1.4.0)
   puppetlabs-apt (= 1.4.2)
   puppetlabs-gcc (= 0.0.3)
-  puppetlabs-lvm (>= 0)
+  puppetlabs-lvm (= 0.4.0)
   puppetlabs-nodejs (= 0.4.0)
   puppetlabs-ntp (= 3.2.0)
   puppetlabs-postgresql (= 3.4.2)

--- a/hieradata/role-mongo.yaml
+++ b/hieradata/role-mongo.yaml
@@ -18,3 +18,12 @@ logstashforwarder_files:
     paths: [ '/var/log/mongodb/mongodb.log' ]
     fields:
       tags: 'mongo'
+
+lvm::volume_groups:
+  data:
+    physical_volumes:
+      - /dev/sdb1
+      - /dev/sdc1
+    logical_volumes:
+      mongo:
+        size: 63.99G

--- a/modules/performanceplatform/manifests/mongo.pp
+++ b/modules/performanceplatform/manifests/mongo.pp
@@ -38,6 +38,9 @@ class performanceplatform::mongo (
     }
 
     if ($disk_mount) {
+      # create lvm as defined in hiera
+      include ::lvm
+
       performanceplatform::mount { $data_dir:
         mountoptions => 'defaults',
         disk         => $disk_mount,
@@ -48,14 +51,6 @@ class performanceplatform::mongo (
       performanceplatform::checks::disk { "${::fqdn}_${data_dir}":
         fqdn => $::fqdn,
         disk => $data_dir,
-      }
-
-      lvm::volume { 'mongo':
-        ensure => 'present',
-        vg     => 'data',
-        pv     => '/dev/sdb1',
-        fstype => 'ext4',
-        before => Performanceplatform::Mount[$data_dir]
       }
     }
 


### PR DESCRIPTION
We have added a new physical volume using the Skyscape UI. 

Devops in all environments will ensure that the new volume is usable.

```
$ sudo fdisk -l
$ echo '- - -' | sudo tee -a /sys/class/scsi_host/*/scan
$ sudo fdisk -l
$ export NEW_DISK=/dev/sdc
$ sudo parted ${NEW_DISK} mklabel msdos
$ sudo parted ${NEW_DISK} mkpart primary 1 100%
```

This change makes LVM use the new volume, which apparently should Just
Work™.

If the new volume isn’t yet available, then puppet should fail at this
point and it should not cause any data corruption (untested).

See https://www.agileplannerapp.com/boards/47856/cards/9211
