### PR TITLE
Switch to the phusion vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,8 +48,8 @@ def get_box(provider)
   provider ||= "virtualbox"
   case provider
   when "vmware"
-    name  = "puppetlabs-ubuntu-server-12042-x64-vf503-nocm"
-    url   = "http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-svr-12042-x64-vf503-nocm.box"
+    name  = "phusion/ubuntu-12.04-amd64"
+    url   = "https://oss-binaries.phusionpassenger.com/vagrant/boxes/latest/ubuntu-12.04-amd64-vmwarefusion.box"
   else
     virtualbox_version = `vboxmanage --version`.strip
     box = $boxes_by_version[virtualbox_version]


### PR DESCRIPTION
I have been having issues with my vagrant vm stopping responding, giving
the error "GuestRpcSendTimedOut: message to toolbox timed out" in the
vmware logs. The phusion vagrant box contains specific support for
building vmware tools when the kernel changes, and also uses lvm and
gives a bigger disk.

We should be looking at building our own templates, but hopefully this
will help until we get time to do that.
