### PR TITLE
In gunicorn_app, pass ensure param to python_app

### DIFF
--- a/modules/performanceplatform/manifests/gunicorn_app.pp
+++ b/modules/performanceplatform/manifests/gunicorn_app.pp
@@ -58,6 +58,7 @@ define performanceplatform::gunicorn_app (
   }
 
   performanceplatform::python_app { $title:
+    ensure          => $ensure,
     app_path        => $app_path,
     virtualenv_path => $virtualenv_path,
     config_path     => $config_path,


### PR DESCRIPTION
This is required to 'ensure->absent' the virtualenv and upstart job associated with a gunicorn_app.
