### PR TITLE
Pass the `$serveraliases` param to nginx

### DIFF
--- a/modules/performanceplatform/manifests/proxy_vhost.pp
+++ b/modules/performanceplatform/manifests/proxy_vhost.pp
@@ -53,6 +53,13 @@ define performanceplatform::proxy_vhost(
 
   $graphite_servername = regsubst($servername, '\.', '_', 'G')
 
+  if ($serveraliases != undef) {
+    validate_array($serveraliases)
+    $vhost_names = $serveraliases
+  } else {
+    $vhost_names = [$servername]
+  }
+
   if $sensu_check {
     performanceplatform::checks::graphite { "5xx_rate_${servername}":
       ensure   => $ensure,
@@ -184,6 +191,7 @@ define performanceplatform::proxy_vhost(
     listen_port           => $port,
     listen_options        => $listen_options,
     proxy                 => "http://${upstream_name}",
+    server_name           => $vhost_names,
     spdy                  => 'on',
     ssl                   => $ssl,
     ssl_port              => $ssl_port,


### PR DESCRIPTION
Since ac5714d when we changed the puppet nginx module used, we
stopped propagating the `$serveraliases` parameter.

This change makes the propagation happen again. The motivation is that
we want to introduce admin-beta and admin pointing at the same thing.

This change enables that temporary step to happen.

See https://www.agileplannerapp.com/boards/15088/cards/9316
