### PR TITLE
Increase elasticsearch disks

### DIFF
--- a/hieradata/role-logs-elasticsearch.yaml
+++ b/hieradata/role-logs-elasticsearch.yaml
@@ -24,3 +24,12 @@ ufw_rules:
 
 ruby_packages:
   - rest-client
+
+lvm::volume_groups:
+  data:
+    physical_volumes:
+      - /dev/sdb1
+      - /dev/sdc1
+    logical_volumes:
+      elasticsearch:
+        size: 255G

--- a/modules/performanceplatform/manifests/elasticsearch.pp
+++ b/modules/performanceplatform/manifests/elasticsearch.pp
@@ -21,13 +21,7 @@ class performanceplatform::elasticsearch(
     disk => $data_dir,
   }
 
-  lvm::volume { 'elasticsearch':
-    ensure => 'present',
-    vg     => 'data',
-    pv     => '/dev/sdb1',
-    fstype => 'ext4',
-    before => Performanceplatform::Mount[$data_dir]
-  }
+  include ::lvm
 
   package { 'estools':
     ensure   => '1.1.2',


### PR DESCRIPTION
Increase elasticsearch disk size to 255GB

For some reason the puppetlabs lvm module will not allow use of the full
256GB due to a mismatch in the number of extents it calculates are
neccessary and the number lvm says is available. Using a non whole
number of gigabytes also fails, so until we can debug the lvm module
properly, lose the extra GB
