### PR TITLE
Remove signontron proxy

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -126,10 +126,6 @@ vhost_proxies:
       "X-Frame-Options": "SAMEORIGIN"
     denied_http_verbs:
       - PURGE
-    custom_locations:
-      stagecraft-reauth:
-        location: /auth/gds/api/users/
-        proxy: 'http://stagecraft-vhost-upstream'
 
   www-vhost:
     servername:    "%{::www_vhost}"


### PR DESCRIPTION
# Overview

Signonotron supports notifications to registered applications.

https://github.com/alphagov/signonotron2/blob/d27541deca3dc667d9e4eb5d7b070d5a98b711cb/lib/sso_push_client.rb

When a user is suspended in signon, or a reauth is requested, we should
honour that in the admin UI.

This means clearing their session from the session storage for the
application, which is currently Redis.

https://github.com/alphagov/performanceplatform-admin/blob/03b86897593466b3831854d8fa90bf8c1834430f/admin/__init__.py#L22-L23

This change removes the proxy directive from nginx. 
# Additional notes

There is a corresponding change in performanceplatform-admin to
handle the signonotron callback – alphagov/performanceplatform-admin#86

**The performanceplatform-admin change needs to be deployed
before this puppet change is merged and deployed.**
