### PR TITLE
Set the uchiwa version to the one we use

### DIFF
--- a/hieradata/role-monitoring.yaml
+++ b/hieradata/role-monitoring.yaml
@@ -145,3 +145,4 @@ ruby_packages:
 uchiwa::install_repo: false
 uchiwa::user: "%{::basic_auth_username}"
 uchiwa::pass: "%{::basic_auth_password}"
+uchiwa::version: '0.4.0-1'


### PR DESCRIPTION
This is the version used in production and staging, the module sets
ensure latest by default. There seems to be a bug in the latest version
affecting us on preview, which was upgraded

https://github.com/sensu/uchiwa/issues/272
