### PR TITLE
Add more verbose logging for postgres

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -42,8 +42,8 @@ mod 'elasticsearch/logstashforwarder',
                                     :git => 'https://github.com/elasticsearch/puppet-logstashforwarder.git',
                                     :ref => 'e07043db7c377da88d1d93b3ae967bf4b7f8dc32'
 mod 'puppetlabs/lvm',             '0.4.0'
-mod 'puppetlabs/rabbitmq',          :git => 'https://github.com/erhudy/puppetlabs-rabbitmq.git',
-                                    :ref => '2f09f3a6a16291645e82daff5e0a22dbba137a22'
+mod 'puppetlabs/rabbitmq',          :git => 'https://github.com/puppetlabs/puppetlabs-rabbitmq.git',
+                                    :ref => '4832bd61b5b1bfea7c9cc985508e65cd10081652'
 mod 'alphagov/mongodb',             :git => 'https://github.com/alphagov/puppetlabs-mongodb.git',
                                     :ref => 'dc077a209efdf8d80fac40d40fec575b6a0949d2'
 mod 'stankevich/python',            :git => 'https://github.com/stankevich/puppet-python.git',

--- a/modules/pp_postgres/manifests/server.pp
+++ b/modules/pp_postgres/manifests/server.pp
@@ -15,4 +15,33 @@ class pp_postgres::server {
   }
 
   Apt::Source['apt.postgresql.org']->Package<|tag == 'postgresql'|>
+
+  # reccommended logging settings for https://github.com/dalibo/pgbadger
+  postgresql::server::config_entry { 'logging_collector':
+      value => 'on',
+  }
+  postgresql::server::config_entry { 'log_min_duration_statement':
+      value => '0',
+  }
+  postgresql::server::config_entry { 'log_line_prefix':
+      value => '%t [%p]: [%l-1] user=%u,db=%d,client=%h ',
+  }
+  postgresql::server::config_entry { 'log_checkpoints':
+      value => 'on',
+  }
+  postgresql::server::config_entry { 'log_connections':
+      value => 'on',
+  }
+  postgresql::server::config_entry { 'log_disconnections':
+      value => 'on',
+  }
+  postgresql::server::config_entry { 'log_lock_waits':
+      value => 'on',
+  }
+  postgresql::server::config_entry { 'log_temp_files':
+      value => '0',
+  }
+  postgresql::server::config_entry { 'log_autovacuum_min_duration':
+      value => '0',
+  }
 }


### PR DESCRIPTION
We want to use the tool https://github.com/dalibo/pgbadger to analyze
what is causing slow queries on the db in production - this adds the
recommended logging config. We also enable capturing stderr, which will
cause postgres to write to a log file.
