### PR TITLE
Update rabbitmq ref

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -43,7 +43,7 @@ mod 'elasticsearch/logstashforwarder',
                                     :ref => 'e07043db7c377da88d1d93b3ae967bf4b7f8dc32'
 mod 'puppetlabs/lvm',             '0.4.0'
 mod 'puppetlabs/rabbitmq',          :git => 'https://github.com/puppetlabs/puppetlabs-rabbitmq.git',
-                                    :ref => '4832bd61b5b1bfea7c9cc985508e65cd10081652'
+                                    :ref => '61991d76cda34c7af5c98ceb53666a0a2b57fda7'
 mod 'alphagov/mongodb',             :git => 'https://github.com/alphagov/puppetlabs-mongodb.git',
                                     :ref => 'dc077a209efdf8d80fac40d40fec575b6a0949d2'
 mod 'stankevich/python',            :git => 'https://github.com/stankevich/puppet-python.git',


### PR DESCRIPTION
I incorrectly assumed that the commit we had lost only affected versions
of rabbitmq prior to 3.4 - it in fact only affected versions after 3.4

Looking at the log for puppetlabs version of the repo, the commit now
referenced appears to to the same thing as the previous referenced
commit in a different way, that should work with 3.4 of rabbitmq
