### PR TITLE
Revert "Use correct module in restructured admin app"

### DIFF
--- a/hieradata/role-frontend-app.yaml
+++ b/hieradata/role-frontend-app.yaml
@@ -36,7 +36,7 @@ spotlight::app::group:      'deploy'
 gunicorn_apps:
   performanceplatform-admin:
     port:          3070
-    app_module:    'application:app'
+    app_module:    'admin:app'
     user:          'deploy'
     group:         'deploy'
     statsd_prefix: 'admin.app'


### PR DESCRIPTION
This reverts commit f804c7d702436e0c7785713bd4f2bd14c3b3650d.

This broke the admin app in production as the new version had not been
deployed and there is an app / puppet dependency
