### PR TITLE
Add auto explain settings

### DIFF
--- a/modules/pp_postgres/manifests/server.pp
+++ b/modules/pp_postgres/manifests/server.pp
@@ -1,5 +1,6 @@
 class pp_postgres::server {
   include('postgresql::server')
+  include 'postgresql::server::contrib'
 
   apt::pin { 'apt.postgresql.org':
     originator => 'apt.postgresql.org',
@@ -52,6 +53,12 @@ class pp_postgres::server {
   }
   postgresql::server::config_entry { 'log_rotation_age':
       value => '1440',
+  }
+  postgresql::server::config_entry { 'auto_explain.log_min_duration':
+      value => '50',
+  }
+  postgresql::server::config_entry { 'shared_preload_libraries':
+      value => 'auto_explain',
   }
 
 }


### PR DESCRIPTION
Documented here.
http://www.postgresql.org/docs/9.3/static/auto-explain.html

The min duration of 50 was chosen because in the 2 week period analysed,
there were about 8000 queries that fall in this range.

This relies on the postgres contrib package being installed. These
changes require a server restart
