### PR TITLE
Ensure write_graphite uses TCP

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -164,6 +164,7 @@ collectd_plugins:
 collectd::interval: 1
 collectd::plugin::write_graphite::graphitehost: graphite
 collectd::plugin::write_graphite::storerates: true
+collectd::plugin::write_graphite::protocol: 'tcp'
 collectd::purge: true
 collectd::purge_config: true
 collectd::recurse: true


### PR DESCRIPTION
In collectd 5.4.0, the default protocol used for
write_graphite changed from TCP to UDP. Be explicit
about the protocol to use so we stay on TCP.
