### PR TITLE
Remove backend-app-3 from backends in varnish

### DIFF
--- a/modules/varnish/templates/backends.vcl.erb
+++ b/modules/varnish/templates/backends.vcl.erb
@@ -7,12 +7,6 @@ backend admin_backend_2 {
     .host = "backend-app-2";
     .probe = admin_healthcheck;
 }
-<% if @pp_environment == 'production' -%>
-backend admin_backend_3 {
-    .host = "backend-app-2";
-    .probe = admin_healthcheck;
-}
-<% end -%>
 backend write_backend_1 {
     .host = "backend-app-1";
     .probe = write_healthcheck;
@@ -21,12 +15,6 @@ backend write_backend_2 {
     .host = "backend-app-2";
     .probe = write_healthcheck;
 }
-<% if @pp_environment == 'production' -%>
-backend write_backend_3 {
-    .host = "backend-app-3";
-    .probe = write_healthcheck;
-}
-<% end -%>
 backend read_backend_1 {
     .host = "backend-app-1";
     .probe = read_healthcheck;
@@ -35,12 +23,6 @@ backend read_backend_2 {
     .host = "backend-app-2";
     .probe = read_healthcheck;
 }
-<% if @pp_environment == 'production' -%>
-backend read_backend_3 {
-    .host = "backend-app-3";
-    .probe = read_healthcheck;
-}
-<% end -%>
 backend stagecraft_backend_1 {
     .host = "backend-app-1";
     .probe = stagecraft_healthcheck;
@@ -49,12 +31,6 @@ backend stagecraft_backend_2 {
     .host = "backend-app-2";
     .probe = stagecraft_healthcheck;
 }
-<% if @pp_environment == 'production' -%>
-backend stagecraft_backend_3 {
-    .host = "backend-app-3";
-    .probe = stagecraft_healthcheck;
-}
-<% end -%>
 
 backend frontend_app_1 {
   .host = "frontend-app-1";
@@ -73,9 +49,3 @@ backend data_backend_2 {
     .probe = data_healthcheck;
 }
 
-<% if @pp_environment == 'production' -%>
-backend data_backend_3 {
-    .host = "backend-app-3";
-    .probe = data_healthcheck;
-}
-<% end -%>


### PR DESCRIPTION
We are not deploying any of the other applications apart from the
collectors on this machine so we will not need to route through any
traffic to it.

At the moment this causes varnish to fail to start as the backends are
not referenced in any of the directors.
