### PR TITLE
Add deploy user's public key

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -22,6 +22,10 @@ accounts:
     groups:
       - gds
   deploy:
+    comment: Deploy user (Preview only)
+    ssh_keys:
+      deploy:
+        key: AAAAB3NzaC1yc2EAAAADAQABAAABAQCroP78pg1I7rnvVufTv9MjDkDg/GdQkM/RWttLLUVoDp/PU4kFHwORbbhDwW9VK+1rQIh9pt/k8RsC1JR5xheR1oIDypH9qq4i4tV1qoEiEYIijZwMM3ZASXZMbAXldPeTozSnmU0HIoa/TJH688GyQXsptEXz+J1ucdvD7eQCy7e1whHYM8aP/8BG4HGBUUUTU6HH2s8bF8APXhwSo/C0k3+2KRnnmqRbPuqTfVLcrVcebO4iH57JLxX1WeRuvorpADcxBdBV5zMsRk1Kc8ennmveXt1Xe4MylJDaABiT+URQ2OUJdrKnT4OpXhjrh6gHpcaeS72DDQ+0awJpeeGn
     groups:
       - gds
   jabley:


### PR DESCRIPTION
In order to help us migrate Performance Platform MongoDB data across to the
GOV.UK MongoDB stack, we need access from Jenkins running in Performance
Platform.

This does that.

Rather than add this key in to roles.mongo.yaml, it seemed better to add it
here so that we keep everything together, and so that the hash doesn't get
blatted accidentally.
