### PR TITLE
Fix dev VM provisioning

### DIFF
--- a/hieradata/role-development.yaml
+++ b/hieradata/role-development.yaml
@@ -140,6 +140,7 @@ python_packages:
   ipython: {}
 
 pp_postgres::primary::stagecraft_password: "securem8"
+pp_postgres::primary::env_sync_password: "securem8"
 performanceplatform::development::stagecraft_password: "securem8"
 apt::always_apt_update: false
 performanceplatform::mongo::data_dir: '/var/lib/mongodb'


### PR DESCRIPTION
a130da017174d36900042771b7006981e86e95c2 introduced a new mandatory parameter.

Without it, provisioning fails:

```
==> development-1: Error: Must pass env_sync_password to Class[Pp_postgres::Primary] at /vagrant/manifests/nodes.pp:46 on node development-1.localdomain
==> development-1: Error: Must pass env_sync_password to Class[Pp_postgres::Primary] at /vagrant/manifests/nodes.pp:46 on node development-1.localdomain
```

Opted to define in YAML here, so that we are aware of everywhere that it
fails and can address accordingly, rather than defining a default in the
class definition.
