### PR TITLE
Add SSH access for Matt Bostock

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -51,6 +51,13 @@ accounts:
         key: AAAAB3NzaC1yc2EAAAADAQABAAABAQDJ/xSWPOq2AqXHrFghnNFgZA673Nq9/e0ma9fD3tTR23/lpkhesqARpR+mOAy6nzv6Ni5Rl/8IIMFLSUmoFeGP15LHtWwtBgFQkzWo0BRVuBF8WFzzbXedR/j4Am3niA/MN1y05tehdeHMkN4KW2FXwyMy2nKLThtE5QPE7sG2mFKZQ5GYbIWPmlLn3uMFmmkZGpErqj8exVgxzah2zka3BVuxjOg9ci7Gvv7r4gquXJ56vm6exyvX/HAjszbYC2FgQkjsouyVfyJp93HDKe4936kVYC+lAbsjF6VVaOdYuVhhq/YescJeinMXuat5abP/wk1g5w4CVjvzeLlebBfx
     groups:
       - gds
+  mattbostock:
+    comment: Matt Bostock
+    ssh_keys:
+      mattbostock:
+        key: AAAAB3NzaC1yc2EAAAADAQABAAACAQDeta2wY+w3jrzguXtyj/vrRX4RfFdutczT23HgdzyTXjK3Me/sI2s5Tw8RlF85PejupG4lVIivIeV/l77WxcCT5PArmmKyRBFLSqM9CzIpN52mxIQSorDpXoROqIYK1vyaAp+rsHRON3qWxzdKg41ignoPt8GUmMOZsZwjCLbiiDPqL9dkpUYmbdBzj8P7r8HamznLMIf4M/tZBeoOX4lDf6cK5DjEalGjPZSoWDdZVxzyf74iqFxisxjxPWjMjy8Jhe3Xq8MVrTjcz5c+J4zQiZsxffyWR57XXzyz79KhvcbJaGnmQwu8Vpr6txrPXDd8CUirRhMDEihpahdvIvnecDnXxJA85KfhCHSGSm9Sc1ukgObd+uLQcDRFYt2o78yLZWtz3HNK3wVL0sjhrfhl17/PD8BMQ6qkZGXb5B5toxYmts29UJIEV3PwSG1U6MUZe3KTm0y+LJnQzEpK9tUFZzlBBrRhrMfbMC027lZpOsHVPu/LBrrD9gcq330RgG7Uik2n1m9XcEjiSTkEc6rttZyJ00ZRl/KK1h/A2j6qA6y/vAxsaVgCzX8hvNOr+VDbBEgZUZiDq0DtZRO2xpjaFNfmju5JTvYIiLNktcdoXrXszRWDw6nWQByDw/ZvjoRNhD+EPcgAciB+gBuWJN/BfBvC0hJNI+uS24gx2svMsQ==
+    groups:
+      - gds
   mattcottingham:
     comment: Matt Cottingham
     ssh_keys:


### PR DESCRIPTION
So that he can look at how existing machines are configured as part of
the work to move Performance Platform on to the GOV.UK stack.
